### PR TITLE
Add multi-sample RAD support and unmapped barcode collation

### DIFF
--- a/libradicl-macros/Cargo.toml
+++ b/libradicl-macros/Cargo.toml
@@ -14,6 +14,6 @@ include = ["src/*.rs", "/Cargo.toml"]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.103"
-quote = "1.0.42"
-syn = { version = "2.0.111", features = ["full"] }
+proc-macro2 = "1.0.106"
+quote = "1.0.45"
+syn = { version = "2.0.117", features = ["full"] }

--- a/libradicl-macros/src/lib.rs
+++ b/libradicl-macros/src/lib.rs
@@ -1,20 +1,20 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Lit, Meta, MetaNameValue};
+use syn::{DeriveInput, Lit, Meta, MetaNameValue, parse_macro_input};
 
 #[proc_macro_derive(UmiTagged, attributes(umi_tagged))]
 pub fn derive_umi_tagged(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    
+
     let name = &input.ident;
     let generics = &input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    
+
     // Parse the attribute to get the field name
     let field_name = get_umi_field_name(&input);
-    
+
     let field_ident = syn::Ident::new(&field_name, proc_macro2::Span::call_site());
-    
+
     let expanded = quote! {
         impl #impl_generics UmiTaggedRecord for #name #ty_generics #where_clause {
             fn umi(&self) -> u64 {
@@ -22,31 +22,28 @@ pub fn derive_umi_tagged(input: TokenStream) -> TokenStream {
             }
         }
     };
-    
+
     TokenStream::from(expanded)
 }
 
 fn get_umi_field_name(input: &DeriveInput) -> String {
     for attr in &input.attrs {
-        if attr.path().is_ident("umi_tagged") {
-            if let Meta::List(meta_list) = &attr.meta {
-                let tokens = &meta_list.tokens;
-                let parsed: Result<MetaNameValue, _> = syn::parse2(tokens.clone());
-                
-                if let Ok(nv) = parsed {
-                    if nv.path.is_ident("umi") {
-                        if let syn::Expr::Lit(expr_lit) = &nv.value {
-                            if let Lit::Str(lit_str) = &expr_lit.lit {
-                                return lit_str.value();
-                            }
-                        }
-                    }
-                }
+        if attr.path().is_ident("umi_tagged")
+            && let Meta::List(meta_list) = &attr.meta
+        {
+            let tokens = &meta_list.tokens;
+            let parsed: Result<MetaNameValue, _> = syn::parse2(tokens.clone());
+
+            if let Ok(nv) = parsed
+                && nv.path.is_ident("umi")
+                && let syn::Expr::Lit(expr_lit) = &nv.value
+                && let Lit::Str(lit_str) = &expr_lit.lit
+            {
+                return lit_str.value();
             }
         }
     }
-    
+
     // Default to "umi" if no attribute is found
     "umi".to_string()
 }
-

--- a/libradicl/Cargo.toml
+++ b/libradicl/Cargo.toml
@@ -29,10 +29,10 @@ serde = { version = "1.0.228", features = ["derive"] }
 dashmap = "^6.1.0"
 bio-types = "1.0.4"
 smallvec = "1.15.1"
-anyhow = "1.0.100"
+anyhow = "1.0.102"
 bincode = "1.3.3"
 itertools = "0.14.0"
-bytemuck = { version = "1.24.0", features = [
+bytemuck = { version = "1.25.0", features = [
   "aarch64_simd",
   "extern_crate_alloc",
 ] }
@@ -42,4 +42,4 @@ noodles = { version = "0.105.0", features = ["bam", "sam"] }
 
 [dev-dependencies]
 needletail = "0.6.3"
-indicatif = "0.18.3"
+indicatif = "0.18.4"

--- a/libradicl/Cargo.toml
+++ b/libradicl/Cargo.toml
@@ -30,6 +30,7 @@ dashmap = "^6.1.0"
 bio-types = "1.0.4"
 smallvec = "1.15.1"
 anyhow = "1.0.100"
+bincode = "1.3.3"
 itertools = "0.14.0"
 bytemuck = { version = "1.24.0", features = [
   "aarch64_simd",

--- a/libradicl/examples/read_chunk_bulk.rs
+++ b/libradicl/examples/read_chunk_bulk.rs
@@ -1,5 +1,4 @@
 use anyhow::{self, Context};
-use libradicl;
 use libradicl::chunk::Chunk;
 use libradicl::record::{PiscemBulkReadRecord, PiscemBulkRecordContext};
 use std::io::BufReader;

--- a/libradicl/examples/read_chunk_single_cell_long_read.rs
+++ b/libradicl/examples/read_chunk_single_cell_long_read.rs
@@ -1,7 +1,7 @@
 use anyhow::{self, Context};
 use libradicl::chunk::Chunk;
 use libradicl::header;
-use libradicl::record::{ScLongReadRecord, ScLongReadRecordContext, KnownSize};
+use libradicl::record::{KnownSize, ScLongReadRecord, ScLongReadRecordContext};
 use std::io::BufReader;
 
 fn main() -> anyhow::Result<()> {
@@ -27,7 +27,11 @@ fn main() -> anyhow::Result<()> {
     );
     assert_eq!(first_chunk.nrec as usize, first_chunk.reads.len());
     for (i, r) in first_chunk.reads.iter().take(10).enumerate() {
-        println!("record {i}: {:?} [[bytes : {}]]", r, ScLongReadRecord::nbytes(r.refs.len() as u32, &tag_context));
+        println!(
+            "record {i}: {:?} [[bytes : {}]]",
+            r,
+            ScLongReadRecord::nbytes(r.refs.len() as u32, &tag_context)
+        );
     }
     println!(
         "printed first 10 records of {} in the first chunk",

--- a/libradicl/src/chunk.rs
+++ b/libradicl/src/chunk.rs
@@ -373,7 +373,7 @@ mod tests {
         let mut cursor = Cursor::new(buf);
 
         // write the prelude
-        let _ = prelude
+        prelude
             .write(&mut cursor)
             .expect("cannot write prelude to buffer");
 
@@ -382,7 +382,7 @@ mod tests {
         let mut file_tag_map = TagMap::with_keyset(&prelude.file_tags.tags);
         file_tag_map.add(TagValue::U16(16));
         file_tag_map.add(TagValue::U16(12));
-        let _ = file_tag_map
+        file_tag_map
             .write_values(&mut cursor)
             .expect("cannot write file tag map");
 

--- a/libradicl/src/collation.rs
+++ b/libradicl/src/collation.rs
@@ -146,10 +146,7 @@ mod tests {
 
     #[test]
     fn collation_manifest_roundtrip() {
-        let mut manifest = CollationManifest::new(vec![
-            "sample".to_string(),
-            "cell".to_string(),
-        ]);
+        let mut manifest = CollationManifest::new(vec!["sample".to_string(), "cell".to_string()]);
         manifest.add_sample_group(SampleGroup {
             key: 0x1234,
             name: Some("sample_A".to_string()),
@@ -188,9 +185,15 @@ mod tests {
         assert_eq!(BarcodeRole::Cell.to_string(), "cell");
         assert_eq!(BarcodeRole::Feature.to_string(), "feature");
 
-        assert_eq!("sample".parse::<BarcodeRole>().unwrap(), BarcodeRole::Sample);
+        assert_eq!(
+            "sample".parse::<BarcodeRole>().unwrap(),
+            BarcodeRole::Sample
+        );
         assert_eq!("cell".parse::<BarcodeRole>().unwrap(), BarcodeRole::Cell);
-        assert_eq!("feature".parse::<BarcodeRole>().unwrap(), BarcodeRole::Feature);
+        assert_eq!(
+            "feature".parse::<BarcodeRole>().unwrap(),
+            BarcodeRole::Feature
+        );
         assert!("unknown".parse::<BarcodeRole>().is_err());
     }
 }

--- a/libradicl/src/collation.rs
+++ b/libradicl/src/collation.rs
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2020-2024 COMBINE-lab.
+ *
+ * This file is part of libradicl
+ * (see https://www.github.com/COMBINE-lab/libradicl).
+ *
+ * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
+ */
+
+//! This module contains types for describing hierarchical collation
+//! of RAD files, supporting multi-barcode protocols like 10x Flex
+//! where reads carry multiple barcodes (e.g., sample + cell).
+
+use serde::{Deserialize, Serialize};
+use std::io::{Read, Write};
+
+/// The semantic role of a barcode in the experiment hierarchy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BarcodeRole {
+    /// Sample/library-level barcode (outermost collation level)
+    Sample,
+    /// Cell-level barcode
+    Cell,
+    /// Feature barcode (e.g., CITE-seq antibody tag)
+    Feature,
+}
+
+impl std::fmt::Display for BarcodeRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BarcodeRole::Sample => write!(f, "sample"),
+            BarcodeRole::Cell => write!(f, "cell"),
+            BarcodeRole::Feature => write!(f, "feature"),
+        }
+    }
+}
+
+impl std::str::FromStr for BarcodeRole {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "sample" => Ok(BarcodeRole::Sample),
+            "cell" => Ok(BarcodeRole::Cell),
+            "feature" => Ok(BarcodeRole::Feature),
+            _ => anyhow::bail!("unknown barcode role: {}", s),
+        }
+    }
+}
+
+/// Describes a single sample group within a hierarchically-collated RAD file.
+/// After collation, chunks belonging to this sample are contiguous in the file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SampleGroup {
+    /// The corrected sample barcode value (2-bit packed)
+    pub key: u64,
+    /// Optional human-readable name for this sample
+    pub name: Option<String>,
+    /// Index of the first chunk belonging to this sample
+    pub chunk_start: u64,
+    /// Number of chunks (cells) in this sample
+    pub num_chunks: u64,
+    /// Total number of records across all chunks in this sample
+    pub num_records: u64,
+}
+
+/// Describes hierarchical chunk organization in a collated RAD file.
+/// Serialized as a sidecar file (`collation_manifest.bin`) alongside
+/// the collated RAD file.
+///
+/// For standard single-barcode collation, no manifest is produced.
+/// For multi-barcode protocols (e.g., 10x Flex), the manifest describes
+/// how chunks are grouped: first by sample barcode, then by cell barcode
+/// within each sample.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollationManifest {
+    /// The collation levels in order from outermost to innermost.
+    /// e.g., ["sample", "cell"] for 10x Flex.
+    pub levels: Vec<String>,
+    /// The sample groups, ordered by their position in the RAD file.
+    pub sample_groups: Vec<SampleGroup>,
+}
+
+impl CollationManifest {
+    /// Create a new empty manifest with the given collation level names.
+    pub fn new(levels: Vec<String>) -> Self {
+        Self {
+            levels,
+            sample_groups: Vec::new(),
+        }
+    }
+
+    /// Add a sample group to the manifest.
+    pub fn add_sample_group(&mut self, group: SampleGroup) {
+        self.sample_groups.push(group);
+    }
+
+    /// Total number of chunks across all samples.
+    pub fn total_chunks(&self) -> u64 {
+        self.sample_groups.iter().map(|g| g.num_chunks).sum()
+    }
+
+    /// Total number of records across all samples.
+    pub fn total_records(&self) -> u64 {
+        self.sample_groups.iter().map(|g| g.num_records).sum()
+    }
+
+    /// Write the manifest to a writer in bincode format.
+    pub fn write_to<W: Write>(&self, writer: &mut W) -> anyhow::Result<()> {
+        let encoded = bincode::serialize(self)
+            .map_err(|e| anyhow::anyhow!("failed to serialize collation manifest: {}", e))?;
+        writer.write_all(&encoded)?;
+        Ok(())
+    }
+
+    /// Read a manifest from a reader in bincode format.
+    pub fn read_from<R: Read>(reader: &mut R) -> anyhow::Result<Self> {
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf)?;
+        let manifest: Self = bincode::deserialize(&buf)
+            .map_err(|e| anyhow::anyhow!("failed to deserialize collation manifest: {}", e))?;
+        Ok(manifest)
+    }
+
+    /// Write the manifest to a file path.
+    pub fn write_to_file(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        let mut file = std::fs::File::create(path)?;
+        self.write_to(&mut file)
+    }
+
+    /// Read a manifest from a file path.
+    pub fn read_from_file(path: &std::path::Path) -> anyhow::Result<Self> {
+        let mut file = std::fs::File::open(path)?;
+        Self::read_from(&mut file)
+    }
+}
+
+// TODO: In the future, support frequency-based sample barcode discovery
+// (similar to knee-finding for cell barcodes). For now, a known sample
+// barcode list is always required.
+//
+// pub fn discover_samples(...) -> ... { ... }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collation_manifest_roundtrip() {
+        let mut manifest = CollationManifest::new(vec![
+            "sample".to_string(),
+            "cell".to_string(),
+        ]);
+        manifest.add_sample_group(SampleGroup {
+            key: 0x1234,
+            name: Some("sample_A".to_string()),
+            chunk_start: 0,
+            num_chunks: 500,
+            num_records: 1_000_000,
+        });
+        manifest.add_sample_group(SampleGroup {
+            key: 0x5678,
+            name: Some("sample_B".to_string()),
+            chunk_start: 500,
+            num_chunks: 400,
+            num_records: 800_000,
+        });
+
+        assert_eq!(manifest.total_chunks(), 900);
+        assert_eq!(manifest.total_records(), 1_800_000);
+
+        // Round-trip through bincode
+        let mut buf: Vec<u8> = Vec::new();
+        manifest.write_to(&mut buf).unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let restored = CollationManifest::read_from(&mut cursor).unwrap();
+
+        assert_eq!(restored.levels, manifest.levels);
+        assert_eq!(restored.sample_groups.len(), 2);
+        assert_eq!(restored.sample_groups[0].key, 0x1234);
+        assert_eq!(restored.sample_groups[0].name, Some("sample_A".to_string()));
+        assert_eq!(restored.sample_groups[1].num_chunks, 400);
+    }
+
+    #[test]
+    fn barcode_role_display_and_parse() {
+        assert_eq!(BarcodeRole::Sample.to_string(), "sample");
+        assert_eq!(BarcodeRole::Cell.to_string(), "cell");
+        assert_eq!(BarcodeRole::Feature.to_string(), "feature");
+
+        assert_eq!("sample".parse::<BarcodeRole>().unwrap(), BarcodeRole::Sample);
+        assert_eq!("cell".parse::<BarcodeRole>().unwrap(), BarcodeRole::Cell);
+        assert_eq!("feature".parse::<BarcodeRole>().unwrap(), BarcodeRole::Feature);
+        assert!("unknown".parse::<BarcodeRole>().is_err());
+    }
+}

--- a/libradicl/src/header.rs
+++ b/libradicl/src/header.rs
@@ -334,13 +334,13 @@ mod tests {
 
         let mut buf: Vec<u8> = Vec::new();
 
-        let _ = prelude
+        prelude
             .write(&mut buf)
             .expect("cannot write prelude to buffer");
 
         let mut file_tag_map = TagMap::with_keyset(&prelude.file_tags.tags);
         file_tag_map.add(TagValue::ArrayU32(vec![1, 2, 3]));
-        let _ = file_tag_map
+        file_tag_map
             .write_values(&mut buf)
             .expect("cannot write file tag map");
 
@@ -408,13 +408,13 @@ mod tests {
 
         let mut buf: Vec<u8> = Vec::new();
 
-        let _ = prelude
+        prelude
             .write(&mut buf)
             .expect("cannot write prelude to buffer");
 
         let mut file_tag_map = TagMap::with_keyset(&prelude.file_tags.tags);
         file_tag_map.add(TagValue::ArrayU32(vec![1, 2, 3]));
-        let _ = file_tag_map
+        file_tag_map
             .write_values(&mut buf)
             .expect("cannot write file tag map");
 

--- a/libradicl/src/io.rs
+++ b/libradicl/src/io.rs
@@ -11,9 +11,9 @@
 //! into and out of primitive types.
 
 use crate::{
-    as_u128, as_u64, as_i128, as_i64, libradicl::rad_types::RadIntId,
-    libradicl::record::ConvertiblePrimitiveInteger, try_as_u128, try_as_u64,
-    try_as_i128, try_as_i64,
+    as_i64, as_i128, as_u64, as_u128, libradicl::rad_types::RadIntId,
+    libradicl::record::ConvertiblePrimitiveInteger, try_as_i64, try_as_i128, try_as_u64,
+    try_as_u128,
 };
 use anyhow::Context;
 use scroll::Pread;
@@ -66,7 +66,6 @@ pub struct NewI64(pub i64);
 /// Wrapper type for [i128] so that we can implement [From]
 /// to read into the relevant builtin type in a generic manner.
 pub struct NewI128(pub i128);
-
 
 /// Allows a distinct [TryFrom] implementation for
 /// converting types read from file into [u64] or [u128]
@@ -182,7 +181,6 @@ pub fn read_into_i64<T: Read>(reader: &mut T, rt: &RadIntId) -> i64 {
     v
 }
 
-
 /// A free function to read into an integer type that is generic over
 /// the size of the integer being returned.  Specifically, the type `B`
 /// can be either a [u64] or a [u128], and the approriate number of
@@ -248,13 +246,12 @@ where
     v
 }
 
-
 /// A fallible free function to read into an integer type that is generic over
 /// the size of the integer being returned.  Specifically, the type `B`
 /// can be either a [u64]/[i64] or a [u128]/[i128], and the approriate number of
 /// bytes of the underlying reader will be consumed and converted into
 /// an integer of the appropriate width. Attempting to read a [RadIntId::U128] into
-/// a `u64` or a [RadIntId::I128] into a `i64` will produce an [anyhow::Error], while all 
+/// a `u64` or a [RadIntId::I128] into a `i64` will produce an [anyhow::Error], while all
 /// other conversions should be successful.
 pub fn try_read_into<T: Read, B>(reader: &mut T, rt: &RadIntId) -> anyhow::Result<B>
 where
@@ -407,10 +404,8 @@ where
                 Err(_) => anyhow::bail!("could not convert i128 to the requested type"),
             }
         }
-
     }
 }
-
 
 /// A free function to read an integer, described by the provided [RadIntId]
 /// into a `u128` container (which is guaranteed to be large enough to
@@ -503,7 +498,6 @@ pub fn try_read_into_u128<T: Read>(reader: &mut T, rt: &RadIntId) -> anyhow::Res
     }
 }
 
-
 /// A free function to read an integer, described by the provided [RadIntId]
 /// into a `i64` container.  Returns an [anyhow::Result] containing
 /// the i64 value read on success, or an error otherwise.
@@ -544,7 +538,6 @@ pub fn try_read_into_i64<T: Read>(reader: &mut T, rt: &RadIntId) -> anyhow::Resu
         _ => {
             anyhow::bail!("cannot read unsigned RadIntId type into i64");
         }
-
     };
     Ok(v)
 }

--- a/libradicl/src/lib.rs
+++ b/libradicl/src/lib.rs
@@ -51,6 +51,7 @@ use std::sync::{Arc, Mutex};
 use std::vec::Vec;
 
 pub mod chunk;
+pub mod collation;
 pub mod constants;
 pub mod exit_codes;
 pub mod header;

--- a/libradicl/src/lib.rs
+++ b/libradicl/src/lib.rs
@@ -31,11 +31,14 @@
 
 use crate as libradicl;
 
-use self::libradicl::rad_types::{RadIntId, MappedFragmentOrientation};
+use self::libradicl::rad_types::{MappedFragmentOrientation, RadIntId};
 use self::libradicl::record::AlevinFryReadRecord;
 use self::libradicl::record::AtacSeqReadRecord;
-use self::libradicl::record::{MappedRecord, KnownSize, CollatableMappedRecord, ConvertiblePrimitiveInteger, RecordHeader, CollatableRecordHeader};
-use self::libradicl::schema::{TempCellInfo,CollateKey};
+use self::libradicl::record::{
+    CollatableMappedRecord, CollatableRecordHeader, ConvertiblePrimitiveInteger, KnownSize,
+    MappedRecord, RecordHeader,
+};
+use self::libradicl::schema::{CollateKey, TempCellInfo};
 #[allow(unused_imports)]
 use ahash::{AHasher, RandomState};
 use bio_types::strand::*;
@@ -53,7 +56,6 @@ use std::vec::Vec;
 pub mod chunk;
 pub mod collation;
 pub mod constants;
-pub mod unmapped;
 pub mod exit_codes;
 pub mod header;
 pub mod io;
@@ -61,10 +63,11 @@ pub mod rad_types;
 pub mod readers;
 pub mod record;
 pub mod schema;
+pub mod unmapped;
 pub mod utils;
 pub mod writers;
-pub use libradicl_macros::UmiTagged;
 pub use chunk::ChunkBuf;
+pub use libradicl_macros::UmiTagged;
 pub use writers::{ConcurrentChunkWriter, RadFileWriter};
 
 #[macro_use]
@@ -298,14 +301,22 @@ pub fn dump_chunk(v: &mut CorrectedCbChunk, owriter: &Mutex<BufWriter<File>>) {
 /// memory exactly as they will reside on disk.  If `compress` is true
 /// the collated chunk will be compressed, and then the result will be
 /// written to the output guarded by `owriter`.
-pub fn collate_temporary_bucket_twopass_generic<B: ConvertiblePrimitiveInteger, T: Read + Seek, U: Write, R: MappedRecord + KnownSize + CollatableMappedRecord<B>>(
+pub fn collate_temporary_bucket_twopass_generic<
+    B: ConvertiblePrimitiveInteger,
+    T: Read + Seek,
+    U: Write,
+    R: MappedRecord + KnownSize + CollatableMappedRecord<B>,
+>(
     reader: &mut BufReader<T>,
     rec_context: &<R as MappedRecord>::ParsingContext,
     nrec: u32,
     owriter: &Mutex<U>,
     compress: bool,
     cb_byte_map: &mut HashMap<u64, TempCellInfo, ahash::RandomState>,
-) -> usize where u64: From<B> {
+) -> usize
+where
+    u64: From<B>,
+{
     let mut tbuf = vec![0u8; 65536];
     let mut total_bytes = 0usize;
     let chunk_header_size = 2 * std::mem::size_of::<u32>() as u64;
@@ -318,14 +329,18 @@ pub fn collate_temporary_bucket_twopass_generic<B: ConvertiblePrimitiveInteger, 
         // read the header of the record
         // we don't bother reading the whole thing here
         // because we will just copy later as need be
-        let tup = <R as CollatableMappedRecord<B>>::from_bytes_collatable_header(reader, rec_context).expect("can read header");
+        let tup =
+            <R as CollatableMappedRecord<B>>::from_bytes_collatable_header(reader, rec_context)
+                .expect("can read header");
 
         // get the entry for this chunk, or create a new one
-        let v = cb_byte_map.entry(tup.collate_key().into()).or_insert(TempCellInfo {
-            offset: chunk_header_size,
-            nbytes: chunk_header_size as u32,
-            nrec: 0_u32,
-        });
+        let v = cb_byte_map
+            .entry(tup.collate_key().into())
+            .or_insert(TempCellInfo {
+                offset: chunk_header_size,
+                nbytes: chunk_header_size as u32,
+                nrec: 0_u32,
+            });
 
         // read the alignment records from the input file
         let na = tup.naln() as usize;
@@ -379,7 +394,9 @@ pub fn collate_temporary_bucket_twopass_generic<B: ConvertiblePrimitiveInteger, 
         // read the header of the record
         // we don't bother reading the whole thing here
         // because we will just copy later as need be
-        let tup = <R as CollatableMappedRecord<B>>::from_bytes_collatable_header(reader, rec_context).expect("can read header");
+        let tup =
+            <R as CollatableMappedRecord<B>>::from_bytes_collatable_header(reader, rec_context)
+                .expect("can read header");
 
         // get the entry for this chunk, or create a new one
         if let Some(v) = cb_byte_map.get_mut(&tup.collate_key().into()) {
@@ -387,11 +404,14 @@ pub fn collate_temporary_bucket_twopass_generic<B: ConvertiblePrimitiveInteger, 
 
             let na = tup.naln() as usize;
             // write the header
-            tup.write_fields(&mut output_buffer, rec_context).expect("could write header");
+            tup.write_fields(&mut output_buffer, rec_context)
+                .expect("could write header");
 
             let bytes_for_aln_rec = R::nbytes_aln(rec_context);
             // copy over the alignment records
-            reader.read_exact(&mut tbuf[0..(bytes_for_aln_rec * na)]).unwrap();
+            reader
+                .read_exact(&mut tbuf[0..(bytes_for_aln_rec * na)])
+                .unwrap();
             output_buffer
                 .write_all(&tbuf[..(bytes_for_aln_rec * na)])
                 .unwrap();
@@ -854,7 +874,11 @@ impl TempBucket {
 /// reaches `flush_limit`, flush the buffer by writing
 /// it to the `output_cache`.
 #[allow(clippy::too_many_arguments)]
-pub fn dump_corrected_cb_chunk_to_temp_file_generic<B: ConvertiblePrimitiveInteger + std::convert::From<u64>, T: Read, R: MappedRecord + KnownSize + CollatableMappedRecord<B>>(
+pub fn dump_corrected_cb_chunk_to_temp_file_generic<
+    B: ConvertiblePrimitiveInteger + std::convert::From<u64>,
+    T: Read,
+    R: MappedRecord + KnownSize + CollatableMappedRecord<B>,
+>(
     reader: &mut BufReader<T>,
     rec_context: &<R as MappedRecord>::ParsingContext,
     correct_map: &HashMap<u64, u64>,
@@ -862,12 +886,15 @@ pub fn dump_corrected_cb_chunk_to_temp_file_generic<B: ConvertiblePrimitiveInteg
     output_cache: &HashMap<u64, Arc<TempBucket>>,
     local_buffers: &mut [Cursor<&mut [u8]>],
     flush_limit: usize,
-) where u64: From<B>, <R as MappedRecord>::ParsingContext: std::fmt::Debug {
+) where
+    u64: From<B>,
+    <R as MappedRecord>::ParsingContext: std::fmt::Debug,
+{
     let mut buf = [0u8; 8];
     let mut tbuf = vec![0u8; 4096];
     //let mut tcursor = Cursor::new(tbuf);
     //tcursor.set_position(0);
-    
+
     // get the number of bytes and records for
     // the next chunk
     reader.read_exact(&mut buf).unwrap();
@@ -878,16 +905,14 @@ pub fn dump_corrected_cb_chunk_to_temp_file_generic<B: ConvertiblePrimitiveInteg
 
     // for each record, read it
     for _ in 0..(nrec as usize) {
-        let mut tup = <R as CollatableMappedRecord<B>>::from_bytes_collatable_header(reader, rec_context).expect("could read header");
+        let mut tup =
+            <R as CollatableMappedRecord<B>>::from_bytes_collatable_header(reader, rec_context)
+                .expect("could read header");
 
         // if this record had a correct or correctable barcode
         if let Some(corrected_id) = correct_map.get(&tup.collate_key().into()) {
-            let mut rr = R::from_bytes_with_header_retain_ori(
-                reader,
-                &mut tup,
-                rec_context,
-                &expected_ori,
-            );
+            let mut rr =
+                R::from_bytes_with_header_retain_ori(reader, &mut tup, rec_context, &expected_ori);
 
             if rr.is_empty() {
                 continue;
@@ -897,7 +922,7 @@ pub fn dump_corrected_cb_chunk_to_temp_file_generic<B: ConvertiblePrimitiveInteg
                 // write the corresponding entry to the
                 // thread-local buffer for this bucket
 
-                let na = tup.naln() as usize; 
+                let na = tup.naln() as usize;
                 // the total number of bytes this record will take
                 let nb = R::nbytes(na as u32, rec_context) as u64;
 
@@ -925,9 +950,13 @@ pub fn dump_corrected_cb_chunk_to_temp_file_generic<B: ConvertiblePrimitiveInteg
                 // now, write the record to the buffer
                 rr.write(bcursor, rec_context).expect("can write record");
                 let alen = bcursor.position() as usize;
-                let actual = alen - blen; 
+                let actual = alen - blen;
                 let expected = R::nbytes(na as u32, rec_context);
-                assert_eq!(expected, actual, "Expected to write {} bytes, but wrote {}.", expected, actual);
+                assert_eq!(
+                    expected, actual,
+                    "Expected to write {} bytes, but wrote {}.",
+                    expected, actual
+                );
 
                 // update number of written records
                 v.num_records_written.fetch_add(1, Ordering::SeqCst);
@@ -938,7 +967,7 @@ pub fn dump_corrected_cb_chunk_to_temp_file_generic<B: ConvertiblePrimitiveInteg
             // in this branch, we don't have access to a correct barcode for
             // what we observed, so we need to discard the remaining part of
             // the record.
-            
+
             // we already read the header, so just the alignments
             let req_len = R::nbytes_aln(rec_context) * tup.naln() as usize;
             let do_resize = req_len > tbuf.len();
@@ -947,9 +976,7 @@ pub fn dump_corrected_cb_chunk_to_temp_file_generic<B: ConvertiblePrimitiveInteg
                 tbuf.resize(req_len, 0);
             }
 
-            reader
-                .read_exact(&mut tbuf[0..req_len])
-                .unwrap();
+            reader.read_exact(&mut tbuf[0..req_len]).unwrap();
 
             if do_resize {
                 tbuf.resize(4096, 0);
@@ -958,7 +985,6 @@ pub fn dump_corrected_cb_chunk_to_temp_file_generic<B: ConvertiblePrimitiveInteg
         }
     }
 }
-
 
 /// Read an input chunk from `reader` and write the
 /// resulting records to the corresponding in-memory
@@ -1088,11 +1114,10 @@ pub fn dump_corrected_cb_chunk_to_temp_file_atac<T: Read>(
     output_cache: &HashMap<u64, Arc<TempBucket>>,
     local_buffers: &mut [Cursor<&mut [u8]>],
     flush_limit: usize,
-    ck: CollateKey
-    // f: F
+    ck: CollateKey, // f: F
 )
 where
-    // F: Fn(u32)
+// F: Fn(u32)
 {
     let mut buf = [0u8; 8];
     let mut tbuf = vec![0u8; 4096];
@@ -1209,7 +1234,6 @@ pub fn as_u8_slice_u8(v: &[u8]) -> &[u8] {
 #[cfg(test)]
 mod tests {
     use crate::BarcodeLookupMap;
-    use needletail;
 
     #[test]
     fn test_barcode_lookup_map() {

--- a/libradicl/src/lib.rs
+++ b/libradicl/src/lib.rs
@@ -53,6 +53,7 @@ use std::vec::Vec;
 pub mod chunk;
 pub mod collation;
 pub mod constants;
+pub mod unmapped;
 pub mod exit_codes;
 pub mod header;
 pub mod io;

--- a/libradicl/src/macros.rs
+++ b/libradicl/src/macros.rs
@@ -198,7 +198,6 @@ macro_rules! as_i64 {
     };
 }
 
-
 /// Convert from an underlying newtype (e.g. a [crate::libradicl::io::NewU8], [crate::libradicl::io::NewU16], [crate::libradicl::io::NewU32],
 /// [crate::libradicl::io::NewU64], [crate::libradicl::io::NewU128]) into a native [u128].
 #[macro_export]
@@ -247,7 +246,7 @@ macro_rules! try_as_u64 {
             type Error = &'static str;
             #[inline(always)]
             fn try_from(x: TryWrapper<$from_type>) -> Result<Self, Self::Error> {
-                Ok(x.0 .0 as u64)
+                Ok(x.0.0 as u64)
             }
         }
     };
@@ -273,7 +272,7 @@ macro_rules! try_as_i64 {
             type Error = &'static str;
             #[inline(always)]
             fn try_from(x: TryWrapper<$from_type>) -> Result<Self, Self::Error> {
-                Ok(x.0 .0 as i64)
+                Ok(x.0.0 as i64)
             }
         }
     };
@@ -289,7 +288,7 @@ macro_rules! try_as_u128 {
             type Error = &'static str;
             #[inline(always)]
             fn try_from(x: TryWrapper<$from_type>) -> Result<Self, Self::Error> {
-                Ok(x.0 .0 as u128)
+                Ok(x.0.0 as u128)
             }
         }
     };
@@ -305,7 +304,7 @@ macro_rules! try_as_i128 {
             type Error = &'static str;
             #[inline(always)]
             fn try_from(x: TryWrapper<$from_type>) -> Result<Self, Self::Error> {
-                Ok(x.0 .0 as i128)
+                Ok(x.0.0 as i128)
             }
         }
     };

--- a/libradicl/src/rad_types.rs
+++ b/libradicl/src/rad_types.rs
@@ -13,25 +13,25 @@
 //! types and traits related to parsing and writing values of specific types.
 
 use crate::{self as libradicl, constants};
-use anyhow::{self, bail, Context};
+use anyhow::{self, Context, bail};
+use bio_types::strand::Strand;
 use libradicl::{tag_value_try_into_int, u8_to_vec_of, u8_to_vec_of_bool, write_tag_value_array};
 use num::cast::AsPrimitive;
 use scroll::Pread;
-use bio_types::strand::Strand;
 
 use std::io::Read;
 use std::io::Write;
 use std::mem;
 
-const U8ID  : u8 = 1_u8;
-const U16ID : u8 = 2_u8;
-const U32ID : u8 = 3_u8;
-const U64ID : u8 = 4_u8;
+const U8ID: u8 = 1_u8;
+const U16ID: u8 = 2_u8;
+const U32ID: u8 = 3_u8;
+const U64ID: u8 = 4_u8;
 const U128ID: u8 = 9_u8;
-const I8ID  : u8 = 10_u8;
-const I16ID : u8 = 11_u8;
-const I32ID : u8 = 12_u8;
-const I64ID : u8 = 13_u8;
+const I8ID: u8 = 10_u8;
+const I16ID: u8 = 11_u8;
+const I32ID: u8 = 12_u8;
+const I64ID: u8 = 13_u8;
 const I128ID: u8 = 14_u8;
 
 /// A **description** for a type tag. This  specifies the name
@@ -133,7 +133,7 @@ impl TagSection {
     }
 
     /// return an iterator over the tag descriptions
-    pub fn iter_desc(&self) -> impl std::iter::ExactSizeIterator<Item=&TagDesc> + use<'_> {
+    pub fn iter_desc(&self) -> impl std::iter::ExactSizeIterator<Item = &TagDesc> + use<'_> {
         self.tags.iter()
     }
 
@@ -183,7 +183,7 @@ pub enum RadIntId {
     I16,
     I32,
     I64,
-    I128
+    I128,
 }
 
 impl RadIntId {
@@ -267,7 +267,6 @@ impl RadIntId {
             _ => {
                 panic!("cannot read an unsigned RadIntId into a i64")
             }
-
         };
         v
     }
@@ -339,9 +338,7 @@ impl RadIntId {
         };
         v
     }
-
 }
-
 
 /// Convert from a [RadIntId], to the corresponding type id (`u8`)
 /// encoding.
@@ -428,41 +425,33 @@ pub trait PrimitiveInteger:
     + AsPrimitive<i64>
     + AsPrimitive<i128>
     + AsPrimitive<isize>
-{}
-
-impl<T: 
-    AsPrimitive<u8>
-    + AsPrimitive<u16>
-    + AsPrimitive<u32>
-    + AsPrimitive<u64>
-    + AsPrimitive<u128>
-    + AsPrimitive<usize>
-    + AsPrimitive<i8>
-    + AsPrimitive<i16>
-    + AsPrimitive<i32>
-    + AsPrimitive<i64>
-    + AsPrimitive<i128>
-    + AsPrimitive<isize>> PrimitiveInteger for T
 {
 }
 
-pub trait PrimitiveUnsignedInteger:
-    PrimitiveInteger + num::Unsigned 
+impl<
+    T: AsPrimitive<u8>
+        + AsPrimitive<u16>
+        + AsPrimitive<u32>
+        + AsPrimitive<u64>
+        + AsPrimitive<u128>
+        + AsPrimitive<usize>
+        + AsPrimitive<i8>
+        + AsPrimitive<i16>
+        + AsPrimitive<i32>
+        + AsPrimitive<i64>
+        + AsPrimitive<i128>
+        + AsPrimitive<isize>,
+> PrimitiveInteger for T
 {
 }
 
-impl<T: PrimitiveInteger + num::Unsigned> PrimitiveUnsignedInteger for T
-{
-}
+pub trait PrimitiveUnsignedInteger: PrimitiveInteger + num::Unsigned {}
 
-pub trait PrimitiveSignedInteger: PrimitiveInteger + num::Signed
-{
-}
+impl<T: PrimitiveInteger + num::Unsigned> PrimitiveUnsignedInteger for T {}
 
-impl<T: PrimitiveInteger + num::Signed> PrimitiveSignedInteger for T
-{
-}
+pub trait PrimitiveSignedInteger: PrimitiveInteger + num::Signed {}
 
+impl<T: PrimitiveInteger + num::Signed> PrimitiveSignedInteger for T {}
 
 impl RadIntId {
     /// Return the number of bytes required
@@ -609,15 +598,15 @@ impl From<u8> for RadAtomicId {
     fn from(x: u8) -> Self {
         match x {
             0 => Self::Bool,
-            U8ID   => Self::Int(RadIntId::U8),
-            U16ID  => Self::Int(RadIntId::U16),
-            U32ID  => Self::Int(RadIntId::U32),
-            U64ID  => Self::Int(RadIntId::U64),
+            U8ID => Self::Int(RadIntId::U8),
+            U16ID => Self::Int(RadIntId::U16),
+            U32ID => Self::Int(RadIntId::U32),
+            U64ID => Self::Int(RadIntId::U64),
             U128ID => Self::Int(RadIntId::U128),
-            I8ID   => Self::Int(RadIntId::I8),
-            I16ID  => Self::Int(RadIntId::I16),
-            I32ID  => Self::Int(RadIntId::I32),
-            I64ID  => Self::Int(RadIntId::I64),
+            I8ID => Self::Int(RadIntId::I8),
+            I16ID => Self::Int(RadIntId::I16),
+            I32ID => Self::Int(RadIntId::I32),
+            I64ID => Self::Int(RadIntId::I64),
             I128ID => Self::Int(RadIntId::I128),
             5 => Self::Float(RadFloatId::F32),
             6 => Self::Float(RadFloatId::F64),
@@ -725,16 +714,16 @@ pub fn encode_type_tag(type_tag: RadType) -> Option<u8> {
 /// then return `Some(`[RadIntId]`)`, otherwise return [None].
 pub fn decode_int_type_tag(type_id: u8) -> Option<RadIntId> {
     match type_id {
-        U8ID    => Some(RadIntId::U8),
-        U16ID   => Some(RadIntId::U16),
-        U32ID   => Some(RadIntId::U32),
-        U64ID   => Some(RadIntId::U64),
-        U128ID  => Some(RadIntId::U128),
-        I8ID    => Some(RadIntId::I8),
-        I16ID   => Some(RadIntId::I16),
-        I32ID   => Some(RadIntId::I32),
-        I64ID   => Some(RadIntId::I64),
-        I128ID  => Some(RadIntId::I128),
+        U8ID => Some(RadIntId::U8),
+        U16ID => Some(RadIntId::U16),
+        U32ID => Some(RadIntId::U32),
+        U64ID => Some(RadIntId::U64),
+        U128ID => Some(RadIntId::U128),
+        I8ID => Some(RadIntId::I8),
+        I16ID => Some(RadIntId::I16),
+        I32ID => Some(RadIntId::I32),
+        I64ID => Some(RadIntId::I64),
+        I128ID => Some(RadIntId::I128),
         _ => None,
     }
 }
@@ -814,7 +803,7 @@ impl From<&Strand> for MappedFragmentOrientation {
         match v {
             Strand::Forward => MappedFragmentOrientation::Forward,
             Strand::Reverse => MappedFragmentOrientation::Reverse,
-            Strand::Unknown => MappedFragmentOrientation::Unknown
+            Strand::Unknown => MappedFragmentOrientation::Unknown,
         }
     }
 }
@@ -824,7 +813,7 @@ impl From<Strand> for MappedFragmentOrientation {
         match v {
             Strand::Forward => MappedFragmentOrientation::Forward,
             Strand::Reverse => MappedFragmentOrientation::Reverse,
-            Strand::Unknown => MappedFragmentOrientation::Unknown
+            Strand::Unknown => MappedFragmentOrientation::Unknown,
         }
     }
 }
@@ -836,13 +825,13 @@ impl From<&MappedFragmentOrientation> for &Strand {
             MappedFragmentOrientation::Reverse => &Strand::Reverse,
             MappedFragmentOrientation::Unknown => &Strand::Unknown,
             // TODO: Think how we should handle paired-end mapping orientations
-            _ => &Strand::Unknown
+            _ => &Strand::Unknown,
         }
     }
 }
 
 impl MappedFragmentOrientation {
-    #[inline] 
+    #[inline]
     pub fn is_unknown(&self) -> bool {
         matches!(*self, MappedFragmentOrientation::Unknown)
     }
@@ -850,14 +839,31 @@ impl MappedFragmentOrientation {
     // generalization of same for Strand
     #[inline]
     pub fn same(&self, s1: &Self) -> bool {
-        matches!((*self, *s1), 
-            (MappedFragmentOrientation::Forward, MappedFragmentOrientation::Forward) | 
-            (MappedFragmentOrientation::Reverse, MappedFragmentOrientation::Reverse) | 
-            (MappedFragmentOrientation::ForwardForward, MappedFragmentOrientation::ForwardForward) | 
-            (MappedFragmentOrientation::ReverseReverse, MappedFragmentOrientation::ReverseReverse) | 
-            (MappedFragmentOrientation::ForwardReverse, MappedFragmentOrientation::ForwardReverse) | 
-            (MappedFragmentOrientation::ReverseForward, MappedFragmentOrientation::ReverseForward) | 
-            (MappedFragmentOrientation::Unknown, MappedFragmentOrientation::Unknown))
+        matches!(
+            (*self, *s1),
+            (
+                MappedFragmentOrientation::Forward,
+                MappedFragmentOrientation::Forward
+            ) | (
+                MappedFragmentOrientation::Reverse,
+                MappedFragmentOrientation::Reverse
+            ) | (
+                MappedFragmentOrientation::ForwardForward,
+                MappedFragmentOrientation::ForwardForward
+            ) | (
+                MappedFragmentOrientation::ReverseReverse,
+                MappedFragmentOrientation::ReverseReverse
+            ) | (
+                MappedFragmentOrientation::ForwardReverse,
+                MappedFragmentOrientation::ForwardReverse
+            ) | (
+                MappedFragmentOrientation::ReverseForward,
+                MappedFragmentOrientation::ReverseForward
+            ) | (
+                MappedFragmentOrientation::Unknown,
+                MappedFragmentOrientation::Unknown
+            )
+        )
     }
 
     /// Given an encoding of the mapped fragment information (`n`) and
@@ -929,15 +935,15 @@ impl From<u8> for RadType {
     fn from(x: u8) -> Self {
         match x {
             0 => RadType::Bool,
-            U8ID   => RadType::Int(RadIntId::U8),
-            U16ID  => RadType::Int(RadIntId::U16),
-            U32ID  => RadType::Int(RadIntId::U32),
-            U64ID  => RadType::Int(RadIntId::U64),
+            U8ID => RadType::Int(RadIntId::U8),
+            U16ID => RadType::Int(RadIntId::U16),
+            U32ID => RadType::Int(RadIntId::U32),
+            U64ID => RadType::Int(RadIntId::U64),
             U128ID => RadType::Int(RadIntId::U128),
-            I8ID   => RadType::Int(RadIntId::I8),
-            I16ID  => RadType::Int(RadIntId::I16),
-            I32ID  => RadType::Int(RadIntId::I32),
-            I64ID  => RadType::Int(RadIntId::I64),
+            I8ID => RadType::Int(RadIntId::I8),
+            I16ID => RadType::Int(RadIntId::I16),
+            I32ID => RadType::Int(RadIntId::I32),
+            I64ID => RadType::Int(RadIntId::I64),
             I128ID => RadType::Int(RadIntId::I128),
             5 => RadType::Float(RadFloatId::F32),
             6 => RadType::Float(RadFloatId::F64),
@@ -1410,7 +1416,10 @@ impl TagDesc {
                         RadAtomicId::Int(RadIntId::U128) => {
                             TagValue::ArrayU128(u8_to_vec_of!(data, u128))
                         }
-                        RadAtomicId::Int(RadIntId::I8) => TagValue::ArrayI8(bytemuck::try_cast_vec::<u8, i8>(data).expect("should be valid to cast from Vec<u8> to Vec<i8>")),
+                        RadAtomicId::Int(RadIntId::I8) => TagValue::ArrayI8(
+                            bytemuck::try_cast_vec::<u8, i8>(data)
+                                .expect("should be valid to cast from Vec<u8> to Vec<i8>"),
+                        ),
                         RadAtomicId::Int(RadIntId::I16) => {
                             TagValue::ArrayI16(u8_to_vec_of!(data, i16))
                         }
@@ -1504,7 +1513,11 @@ pub struct TagViewMap<'a> {
 #[inline(always)]
 fn try_add(dat: &mut Vec<TagValue>, keys: &[TagDesc], val: TagValue) -> anyhow::Result<()> {
     let next_idx = dat.len();
-    anyhow::ensure!(next_idx < keys.len(), "Attempted to add a TagVal {val:?} at index {next_idx}, but there are only {} keys in the keyset", keys.len());
+    anyhow::ensure!(
+        next_idx < keys.len(),
+        "Attempted to add a TagVal {val:?} at index {next_idx}, but there are only {} keys in the keyset",
+        keys.len()
+    );
     anyhow::ensure!(
         keys[next_idx].matches_value_type(&val),
         "The TagValue that was attempted to be added {val:?} didn't match the next TagDesc {:?}",
@@ -1515,7 +1528,11 @@ fn try_add(dat: &mut Vec<TagValue>, keys: &[TagDesc], val: TagValue) -> anyhow::
 }
 
 #[inline(always)]
-pub fn get_tag_by_name<'a>(key: &str, dat: &'a [TagValue], keys: &[TagDesc]) -> Option<&'a TagValue> {
+pub fn get_tag_by_name<'a>(
+    key: &str,
+    dat: &'a [TagValue],
+    keys: &[TagDesc],
+) -> Option<&'a TagValue> {
     for (k, val) in keys.iter().zip(dat.iter()) {
         if k.name == key {
             return Some(val);
@@ -1656,7 +1673,12 @@ impl TagMap {
     /// variants and must be the next two consecutive values to be added to this map
     /// (i.e. the tags `"{name}.keys"` and `"{name}.values"` must occupy the next two
     /// available slots in the keyset).
-    pub fn insert_map_tags(&mut self, name: &str, keys: TagValue, vals: TagValue) -> anyhow::Result<()> {
+    pub fn insert_map_tags(
+        &mut self,
+        name: &str,
+        keys: TagValue,
+        vals: TagValue,
+    ) -> anyhow::Result<()> {
         let keys_tag_name = format!("{name}.keys");
         let vals_tag_name = format!("{name}.values");
 
@@ -1665,7 +1687,10 @@ impl TagMap {
             next_idx < self.keys.len() && self.keys[next_idx].name == keys_tag_name,
             "insert_map_tags: expected next tag to be '{}' but found '{}'",
             keys_tag_name,
-            self.keys.get(next_idx).map(|k| k.name.as_str()).unwrap_or("<none>")
+            self.keys
+                .get(next_idx)
+                .map(|k| k.name.as_str())
+                .unwrap_or("<none>")
         );
         self.try_add(keys)?;
 
@@ -1674,7 +1699,10 @@ impl TagMap {
             next_idx < self.keys.len() && self.keys[next_idx].name == vals_tag_name,
             "insert_map_tags: expected next tag to be '{}' but found '{}'",
             vals_tag_name,
-            self.keys.get(next_idx).map(|k| k.name.as_str()).unwrap_or("<none>")
+            self.keys
+                .get(next_idx)
+                .map(|k| k.name.as_str())
+                .unwrap_or("<none>")
         );
         self.try_add(vals)?;
 
@@ -1879,12 +1907,14 @@ mod tests {
             TagSection::from_bytes_with_label(&mut c, TagSectionLabel::FileTags).unwrap()
         };
         let read_map = section_keys_bytes
-            .parse_tags_from_bytes(&mut std::io::Cursor::new(&buf[{
-                // skip over the section schema bytes to reach tag values
-                let mut tmp = Vec::<u8>::new();
-                section.write(&mut tmp).unwrap();
-                tmp.len()
-            }..]))
+            .parse_tags_from_bytes(&mut std::io::Cursor::new(
+                &buf[{
+                    // skip over the section schema bytes to reach tag values
+                    let mut tmp = Vec::<u8>::new();
+                    section.write(&mut tmp).unwrap();
+                    tmp.len()
+                }..],
+            ))
             .unwrap();
         assert_eq!(read_map.get("bc_len"), Some(&TagValue::U16(16)));
         assert_eq!(

--- a/libradicl/src/readers.rs
+++ b/libradicl/src/readers.rs
@@ -21,8 +21,8 @@ use crossbeam_queue::ArrayQueue;
 use scroll::Pwrite;
 use std::io::{BufRead, Cursor, Seek};
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
 /// This represents an empty callback of the appropriate type for the [ParallelChunkReader] and
@@ -460,7 +460,11 @@ impl<R: MappedRecord, T: BufRead + Seek> ParallelRadReader<R, T> {
     /// This function will read and parse the file_tag_map.
     /// This [ParallelRadReader] will expect to provide chunks to `num_consumers` different
     /// threads once the [Self::start_chunk_parsing()] method has been called.
-    pub fn from_prelude(mut reader: T, prelude: RadPrelude, num_consumers: std::num::NonZeroUsize) -> Self {
+    pub fn from_prelude(
+        mut reader: T,
+        prelude: RadPrelude,
+        num_consumers: std::num::NonZeroUsize,
+    ) -> Self {
         let file_tag_map = prelude
             .file_tags
             .parse_tags_from_bytes(&mut reader)
@@ -474,13 +478,16 @@ impl<R: MappedRecord, T: BufRead + Seek> ParallelRadReader<R, T> {
         }
     }
 
-
-
     /// Create a new [ParallelRadReader] given the provided `prelude` and `file_tag_map`.  It is
     /// assumed that the input `reader` has been consumed up to the point of the first chunk.
     /// This [ParallelRadReader] will expect to provide chunks to `num_consumers` different
     /// threads once the [Self::start_chunk_parsing()] method has been called.
-    pub fn from_prelude_and_file_tag_map(reader: T, prelude: RadPrelude, file_tag_map: TagMap, num_consumers: std::num::NonZeroUsize) -> Self {
+    pub fn from_prelude_and_file_tag_map(
+        reader: T,
+        prelude: RadPrelude,
+        file_tag_map: TagMap,
+        num_consumers: std::num::NonZeroUsize,
+    ) -> Self {
         Self {
             prelude,
             file_tag_map,
@@ -489,7 +496,6 @@ impl<R: MappedRecord, T: BufRead + Seek> ParallelRadReader<R, T> {
             done_var: Arc::new(AtomicBool::new(false)),
         }
     }
-
 
     /// Get an `std::sync::Arc` holding the underlying `ArrayQueue` associated with this reader.
     /// This allows independent parser threads to obtain `MetaChunk`s, over which they can iterate
@@ -607,11 +613,7 @@ impl<T: BufRead> Iterator for ChunkCountIterator<T> {
     fn next(&mut self) -> Option<Self::Item> {
         let c = self.current_chunk;
         self.current_chunk += 1;
-        if c <= self.num_chunks {
-            Some(c)
-        } else {
-            None
-        }
+        if c <= self.num_chunks { Some(c) } else { None }
     }
 
     #[inline(always)]

--- a/libradicl/src/record.rs
+++ b/libradicl/src/record.rs
@@ -17,14 +17,16 @@ use crate::io::{
 use crate::{
     io as rad_io,
     rad_types::{
-        MappedFragmentOrientation, MappingType, PrimitiveInteger, RadIntId, RadType, 
+        MappedFragmentOrientation, MappingType, PrimitiveInteger, RadIntId, RadType,
         TagSection, TagValue,
     },
     utils
 };
+use crate::collation::BarcodeRole;
 use libradicl_macros::UmiTagged;
 use anyhow::{self, bail, Context};
 use bio_types::strand::{Strand, Same};
+use smallvec::SmallVec;
 use scroll::Pread;
 use std::io::{Read, Write};
 use std::mem;
@@ -2205,6 +2207,526 @@ impl<B: ConvertiblePrimitiveInteger> ScLongReadRecordT<B> {
     }
 }
 
+// ====== Multi-barcode records (for 10x Flex and similar protocols) ======
+
+/// The default [MultiBarcodeReadRecordT] holds barcodes in [u64]
+pub type MultiBarcodeReadRecord = MultiBarcodeReadRecordT<u64>;
+
+/// A [MultiBarcodeReadRecordT] that holds barcodes in [u64] and is explicit about this
+pub type MultiBarcodeReadRecordU64 = MultiBarcodeReadRecordT<u64>;
+
+/// A [MultiBarcodeReadRecordT] that holds barcodes in [u128] and is explicit about this
+pub type MultiBarcodeReadRecordU128 = MultiBarcodeReadRecordT<u128>;
+
+/// Maximum number of barcode levels supported inline (no heap allocation).
+/// This covers all known protocols (typically 2, at most ~4).
+pub const MAX_INLINE_BARCODES: usize = 4;
+
+/// A read record carrying multiple barcodes for multi-barcode protocols.
+/// Uses SmallVec with a small inline capacity since the number of barcodes
+/// per read is always very small (typically 2, at most ~4).
+/// SmallVec avoids heap allocation for these small counts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultiBarcodeReadRecordT<B: ConvertiblePrimitiveInteger> {
+    /// Barcodes at each level: b0, b1, ..., b{N-1} in order.
+    /// For 10x Flex: b0 = sample barcode, b1 = cell barcode.
+    pub barcodes: SmallVec<[B; MAX_INLINE_BARCODES]>,
+    pub umi: u64,
+    pub dirs: Vec<bool>,
+    pub refs: Vec<u32>,
+}
+
+impl<B: ConvertiblePrimitiveInteger> UmiTaggedRecord for MultiBarcodeReadRecordT<B> {
+    fn umi(&self) -> u64 {
+        self.umi
+    }
+}
+
+/// Context needed to read a multi-barcode record.
+/// Stores the integer type for each barcode level and the UMI type.
+#[derive(Debug, Clone)]
+pub struct MultiBarcodeRecordContext {
+    /// The integer type of each barcode level (b0, b1, ...)
+    pub bc_types: SmallVec<[RadIntId; MAX_INLINE_BARCODES]>,
+    /// The integer type of the UMI
+    pub umit: RadIntId,
+    /// The semantic roles of each barcode level
+    pub roles: SmallVec<[BarcodeRole; MAX_INLINE_BARCODES]>,
+}
+
+impl RecordContext for MultiBarcodeRecordContext {
+    fn get_context_from_tag_section(
+        ft: &TagSection,
+        rt: &TagSection,
+        _at: &TagSection,
+    ) -> anyhow::Result<Self> {
+        // Determine the number of barcodes from the file-level tag
+        let num_barcodes_tag = ft.get_tag_type("num_barcodes");
+        let num_barcodes = if let Some(RadType::Int(_)) = num_barcodes_tag {
+            // We'll read the actual value from the tag map at a higher level;
+            // here we discover barcode tags from the read-level tag section.
+            // Count how many b0, b1, b2, ... tags exist.
+            let mut count = 0usize;
+            while rt.get_tag_type(&format!("b{}", count)).is_some() {
+                count += 1;
+            }
+            if count == 0 {
+                bail!("multi-barcode record context: num_barcodes file tag present but no bN read-level tags found");
+            }
+            count
+        } else {
+            bail!("multi-barcode record context requires a 'num_barcodes' file-level tag");
+        };
+
+        let mut bc_types = SmallVec::new();
+        for i in 0..num_barcodes {
+            let tag_name = format!("b{}", i);
+            let bct = rt.get_tag_type(&tag_name)
+                .ok_or_else(|| anyhow::anyhow!("multi-barcode record context requires a '{}' read-level tag", tag_name))?;
+            if let RadType::Int(x) = bct {
+                bc_types.push(x);
+            } else {
+                bail!("multi-barcode record context requires that '{}' tag is of type RadType::Int", tag_name);
+            }
+        }
+
+        let umit = rt
+            .get_tag_type("u")
+            .expect("multi-barcode record context requires a 'u' read-level tag");
+        let umit = if let RadType::Int(x) = umit {
+            x
+        } else {
+            bail!("multi-barcode record context requires that 'u' tag is of type RadType::Int");
+        };
+
+        // Parse barcode roles from file-level tag if present, otherwise use defaults
+        let roles = Self::parse_roles_or_default(ft, num_barcodes)?;
+
+        Ok(Self {
+            bc_types,
+            umit,
+            roles,
+        })
+    }
+}
+
+impl MultiBarcodeRecordContext {
+    /// Create a new context from explicit barcode types, UMI type, and roles.
+    pub fn new(
+        bc_types: SmallVec<[RadIntId; MAX_INLINE_BARCODES]>,
+        umit: RadIntId,
+        roles: SmallVec<[BarcodeRole; MAX_INLINE_BARCODES]>,
+    ) -> Self {
+        Self { bc_types, umit, roles }
+    }
+
+    /// Number of barcode levels in this context.
+    pub fn num_barcodes(&self) -> usize {
+        self.bc_types.len()
+    }
+
+    /// Total bytes for all barcode fields in a record.
+    pub fn total_bc_bytes(&self) -> usize {
+        self.bc_types.iter().map(|t| t.bytes_for_type()).sum()
+    }
+
+    /// Parse barcode roles from the file-level tag section, or use defaults.
+    fn parse_roles_or_default(
+        ft: &TagSection,
+        num_barcodes: usize,
+    ) -> anyhow::Result<SmallVec<[BarcodeRole; MAX_INLINE_BARCODES]>> {
+        // TODO: Parse barcode_roles from file-level tag when the ArrayString
+        // tag type is implemented. For now, use defaults.
+        let _ = ft;
+        let mut roles = SmallVec::new();
+        for i in 0..num_barcodes {
+            if i == 0 && num_barcodes > 1 {
+                roles.push(BarcodeRole::Sample);
+            } else {
+                roles.push(BarcodeRole::Cell);
+            }
+        }
+        Ok(roles)
+    }
+}
+
+/// Header information for a [MultiBarcodeReadRecord].
+pub struct MultiBarcodeReadRecordHeader<B: ConvertiblePrimitiveInteger> {
+    pub naln: u32,
+    pub barcodes: SmallVec<[B; MAX_INLINE_BARCODES]>,
+    pub umi: u64,
+}
+
+impl<B: ConvertiblePrimitiveInteger> RecordHeader for MultiBarcodeReadRecordHeader<B> {
+    type RecordType = MultiBarcodeReadRecordT<B>;
+    fn naln(&self) -> u32 {
+        self.naln
+    }
+}
+
+impl<B: ConvertiblePrimitiveInteger> CollatableRecordHeader<B> for MultiBarcodeReadRecordHeader<B> {
+    /// Returns the innermost (last) barcode as the collation key,
+    /// which is typically the cell barcode.
+    fn collate_key(&self) -> B {
+        *self.barcodes.last().expect("multi-barcode header must have at least one barcode")
+    }
+
+    fn write_fields<W: Write>(
+        &self,
+        writer: &mut W,
+        ctx: &<<Self as RecordHeader>::RecordType as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<()> {
+        let na: u32 = self.naln();
+        RadIntId::U32
+            .write_to(na, writer)
+            .context("couldn't write number of alignments for multi-barcode record")?;
+        for (bc, bct) in self.barcodes.iter().zip(ctx.bc_types.iter()) {
+            bct.write_to(*bc, writer)
+                .context("couldn't write barcode field for multi-barcode record")?;
+        }
+        ctx.umit
+            .write_to(self.umi, writer)
+            .context("couldn't write umi field for multi-barcode record")?;
+        Ok(())
+    }
+}
+
+impl<B: ConvertiblePrimitiveInteger> KnownSize for MultiBarcodeReadRecordT<B> {
+    fn nbytes(na: u32, ctx: &<Self as MappedRecord>::ParsingContext) -> usize {
+        // for na field
+        std::mem::size_of::<u32>()
+        // for all barcodes
+        + ctx.total_bc_bytes()
+        // for umi
+        + ctx.umit.bytes_for_type()
+        // an ori_ref for each alignment
+        + (na as usize * Self::nbytes_aln(ctx))
+    }
+
+    fn nbytes_aln(_ctx: &<Self as MappedRecord>::ParsingContext) -> usize {
+        // ori_ref
+        std::mem::size_of::<u32>()
+    }
+}
+
+impl<B: ConvertiblePrimitiveInteger> MappedRecord for MultiBarcodeReadRecordT<B> {
+    type ParsingContext = MultiBarcodeRecordContext;
+    /// Peek returns all barcodes and the UMI
+    type PeekResult = (SmallVec<[B; MAX_INLINE_BARCODES]>, u64);
+
+    fn is_empty(&self) -> bool {
+        self.refs.is_empty()
+    }
+
+    fn num_aln(&self) -> usize {
+        self.refs.len()
+    }
+
+    fn refs(&self) -> &[u32] {
+        &self.refs
+    }
+
+    fn has_alignment_on_strand(&self, s: Strand) -> bool {
+        match s {
+            Strand::Unknown => !self.refs.is_empty(),
+            Strand::Forward => self.dirs.iter().any(|&x| x),
+            Strand::Reverse => self.dirs.iter().any(|&x| !x),
+        }
+    }
+
+    #[inline]
+    fn peek_record(buf: &[u8], ctx: &Self::ParsingContext) -> Self::PeekResult {
+        let na_size = mem::size_of::<u32>();
+        let _na = buf.pread::<u32>(0).unwrap();
+
+        let mut offset = na_size;
+        let mut barcodes = SmallVec::new();
+        for bct in &ctx.bc_types {
+            let bc: B = match bct {
+                RadIntId::U8 => NewU8(buf.pread::<u8>(offset).unwrap()).into(),
+                RadIntId::U16 => NewU16(buf.pread::<u16>(offset).unwrap()).into(),
+                RadIntId::U32 => NewU32(buf.pread::<u32>(offset).unwrap()).into(),
+                RadIntId::U64 => NewU64(buf.pread::<u64>(offset).unwrap()).into(),
+                RadIntId::U128 => NewU128(buf.pread::<u128>(offset).unwrap()).into(),
+                _ => panic!("signed barcode integer encodings are not supported"),
+            };
+            barcodes.push(bc);
+            offset += bct.bytes_for_type();
+        }
+
+        let umi = match ctx.umit {
+            RadIntId::U8 => buf.pread::<u8>(offset).unwrap() as u64,
+            RadIntId::U16 => buf.pread::<u16>(offset).unwrap() as u64,
+            RadIntId::U32 => buf.pread::<u32>(offset).unwrap() as u64,
+            RadIntId::U64 => buf.pread::<u64>(offset).unwrap(),
+            RadIntId::U128 => panic!("u128 is currently not supported as a umi type"),
+            _ => panic!("signed umi integer encodings are not supported"),
+        };
+        (barcodes, umi)
+    }
+
+    #[inline]
+    fn from_bytes_with_context<T: Read>(reader: &mut T, ctx: &Self::ParsingContext) -> Self {
+        let mut rbuf = [0u8; 255];
+
+        // Read naln
+        reader.read_exact(&mut rbuf[0..4]).unwrap();
+        let na = u32::from_le_bytes([rbuf[0], rbuf[1], rbuf[2], rbuf[3]]);
+
+        // Read all barcodes
+        let mut barcodes = SmallVec::new();
+        for bct in &ctx.bc_types {
+            let bc: B = rad_io::read_into(reader, bct);
+            barcodes.push(bc);
+        }
+
+        // Read UMI
+        let umi = rad_io::read_into_u64(reader, &ctx.umit);
+
+        let mut rec = Self {
+            barcodes,
+            umi,
+            dirs: Vec::with_capacity(na as usize),
+            refs: Vec::with_capacity(na as usize),
+        };
+
+        // Read alignment records (same format as AlevinFryReadRecordT)
+        for _ in 0..(na as usize) {
+            reader.read_exact(&mut rbuf[0..4]).unwrap();
+            let v = rbuf.pread::<u32>(0).unwrap();
+            let dir = (v & utils::MASK_LOWER_31_U32) != 0;
+            rec.dirs.push(dir);
+            rec.refs.push(v & utils::MASK_TOP_BIT_U32);
+        }
+        rec
+    }
+
+    #[inline]
+    fn write<W: Write>(&self, writer: &mut W, ctx: &Self::ParsingContext) -> anyhow::Result<()> {
+        let na: u32 = self.refs.len() as u32;
+        RadIntId::U32
+            .write_to(na, writer)
+            .context("couldn't write number of alignments for multi-barcode record")?;
+
+        // Write all barcodes
+        for (bc, bct) in self.barcodes.iter().zip(ctx.bc_types.iter()) {
+            bct.write_to(*bc, writer)
+                .context("couldn't write barcode field for multi-barcode record")?;
+        }
+
+        ctx.umit
+            .write_to(self.umi, writer)
+            .context("couldn't write umi field for multi-barcode record")?;
+
+        // Write alignment records
+        let dir_iter = self.dirs.iter();
+        for (dir, ref_idx) in itertools::izip!(dir_iter.chain(std::iter::repeat(&false)), &self.refs) {
+            let encoded_dir: u32 = if *dir { 1_u32 << 31 } else { 0_u32 };
+            let encoded_dir_ref: u32 = ref_idx | encoded_dir;
+            writer
+                .write_all(&encoded_dir_ref.to_le_bytes())
+                .context("couldn't write compressed_ori_refid for multi-barcode record")?;
+        }
+        Ok(())
+    }
+}
+
+impl<B: ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for MultiBarcodeReadRecordT<B> {
+    type CollatableRecordHeader = MultiBarcodeReadRecordHeader<B>;
+
+    #[inline]
+    fn from_bytes_with_header_retain_ori<T: Read>(
+        reader: &mut T,
+        hdr: &mut Self::CollatableRecordHeader,
+        _ctx: &<Self as MappedRecord>::ParsingContext,
+        expected_ori: &MappedFragmentOrientation,
+    ) -> Self {
+        let rec = MultiBarcodeReadRecordT::<B>::from_bytes_with_header_keep_ori(
+            reader,
+            hdr.barcodes.clone(),
+            hdr.umi,
+            hdr.naln,
+            expected_ori.into(),
+        );
+        hdr.naln = rec.refs.len() as u32;
+        rec
+    }
+
+    /// The collation key is the innermost (last) barcode, typically the cell barcode.
+    fn set_collate_key(&mut self, k: B) {
+        if let Some(last) = self.barcodes.last_mut() {
+            *last = k;
+        }
+    }
+
+    fn collate_key(&self) -> B {
+        *self.barcodes.last().expect("multi-barcode record must have at least one barcode")
+    }
+
+    fn from_bytes_collatable_header<T: Read>(
+        reader: &mut T,
+        context: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
+        let mut rbuf = [0u8; 4];
+        reader.read_exact(&mut rbuf).unwrap();
+        let na = u32::from_le_bytes(rbuf);
+
+        let mut barcodes = SmallVec::new();
+        for bct in &context.bc_types {
+            let bc: B = rad_io::read_into(reader, bct);
+            barcodes.push(bc);
+        }
+
+        let umi = rad_io::read_into_u64(reader, &context.umit);
+
+        Ok(Self::CollatableRecordHeader {
+            naln: na,
+            barcodes,
+            umi,
+        })
+    }
+
+    fn peek_collatable_header(
+        buf: &[u8],
+        ctx: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
+        let na_size = mem::size_of::<u32>();
+        let na = buf.pread::<u32>(0).unwrap();
+
+        let mut offset = na_size;
+        let mut barcodes = SmallVec::new();
+        for bct in &ctx.bc_types {
+            let bc: B = match bct {
+                RadIntId::U8 => NewU8(buf.pread::<u8>(offset).unwrap()).into(),
+                RadIntId::U16 => NewU16(buf.pread::<u16>(offset).unwrap()).into(),
+                RadIntId::U32 => NewU32(buf.pread::<u32>(offset).unwrap()).into(),
+                RadIntId::U64 => NewU64(buf.pread::<u64>(offset).unwrap()).into(),
+                RadIntId::U128 => NewU128(buf.pread::<u128>(offset).unwrap()).into(),
+                _ => panic!("signed barcode integer encodings are not supported"),
+            };
+            barcodes.push(bc);
+            offset += bct.bytes_for_type();
+        }
+
+        let umi = match ctx.umit {
+            RadIntId::U8 => buf.pread::<u8>(offset).unwrap() as u64,
+            RadIntId::U16 => buf.pread::<u16>(offset).unwrap() as u64,
+            RadIntId::U32 => buf.pread::<u32>(offset).unwrap() as u64,
+            RadIntId::U64 => buf.pread::<u64>(offset).unwrap(),
+            RadIntId::U128 => panic!("u128 is currently not supported as a umi type"),
+            _ => panic!("signed umi integer encodings are not supported"),
+        };
+
+        Ok(Self::CollatableRecordHeader {
+            naln: na,
+            barcodes,
+            umi,
+        })
+    }
+}
+
+// ====== Hierarchical collation trait ======
+
+/// Trait for records that support hierarchical collation across multiple
+/// barcode levels. This extends [CollatableMappedRecord] to provide
+/// level-indexed access to barcodes.
+///
+/// Standard single-barcode record types do NOT implement this trait,
+/// preserving the zero-overhead guarantee for the common case.
+pub trait HierarchicallyCollatable<B: ConvertiblePrimitiveInteger>:
+    CollatableMappedRecord<B>
+{
+    /// Number of barcode levels in this record (e.g., 2 for sample + cell).
+    fn num_collation_levels(&self) -> usize;
+
+    /// Get the collation key at a specific level.
+    /// Level 0 is the outermost (e.g., sample), level N-1 is the innermost (e.g., cell).
+    fn collation_key_at_level(&self, level: usize) -> B;
+
+    /// Set the collation key at a specific level.
+    fn set_collation_key_at_level(&mut self, level: usize, k: B);
+}
+
+impl<B: ConvertiblePrimitiveInteger> HierarchicallyCollatable<B> for MultiBarcodeReadRecordT<B> {
+    fn num_collation_levels(&self) -> usize {
+        self.barcodes.len()
+    }
+
+    fn collation_key_at_level(&self, level: usize) -> B {
+        self.barcodes[level]
+    }
+
+    fn set_collation_key_at_level(&mut self, level: usize, k: B) {
+        self.barcodes[level] = k;
+    }
+}
+
+// Helper methods for MultiBarcodeReadRecordT
+impl<B: ConvertiblePrimitiveInteger> MultiBarcodeReadRecordT<B> {
+    /// Read the record header (naln, all barcodes, umi) from a reader.
+    pub fn from_bytes_record_header<T: Read>(
+        reader: &mut T,
+        bc_types: &[RadIntId],
+        umit: &RadIntId,
+    ) -> (SmallVec<[B; MAX_INLINE_BARCODES]>, u64, u32) {
+        let mut rbuf = [0u8; 4];
+        reader.read_exact(&mut rbuf).unwrap();
+        let na = u32::from_le_bytes(rbuf);
+
+        let mut barcodes = SmallVec::new();
+        for bct in bc_types {
+            let bc: B = rad_io::read_into(reader, bct);
+            barcodes.push(bc);
+        }
+
+        let umi = rad_io::read_into_u64(reader, umit);
+        (barcodes, umi, na)
+    }
+
+    /// Read a record from a reader, retaining only alignments matching the
+    /// prescribed orientation.
+    #[inline]
+    pub fn from_bytes_with_header_keep_ori<T: Read>(
+        reader: &mut T,
+        barcodes: SmallVec<[B; MAX_INLINE_BARCODES]>,
+        umi: u64,
+        na: u32,
+        expected_ori: &Strand,
+    ) -> Self {
+        let mut rbuf = [0u8; 255];
+        let mut rec = Self {
+            barcodes,
+            umi,
+            dirs: Vec::with_capacity(na as usize),
+            refs: Vec::with_capacity(na as usize),
+        };
+
+        for _ in 0..(na as usize) {
+            reader.read_exact(&mut rbuf[0..4]).unwrap();
+            let v = rbuf.pread::<u32>(0).unwrap();
+
+            // fw if the leftmost bit is 1, otherwise rc
+            let strand = if (v & utils::MASK_LOWER_31_U32) > 0 {
+                Strand::Forward
+            } else {
+                Strand::Reverse
+            };
+
+            if expected_ori.same(&strand) || expected_ori.is_unknown() {
+                let dir = (v & utils::MASK_LOWER_31_U32) != 0;
+                rec.dirs.push(dir);
+                rec.refs.push(v & utils::MASK_TOP_BIT_U32);
+            }
+        }
+
+        // make sure these are sorted in this step.
+        let indices = argsort(&rec.refs);
+        reorder_in_place(&mut rec.refs, &indices);
+        reorder_in_place(&mut rec.dirs, &indices);
+        rec
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::rad_types::{RadIntId, TagSection, TagSectionLabel};
@@ -2243,5 +2765,54 @@ mod tests {
 
         //println!("rec = {:?}, new_rec = {:?}", rec, new_rec);
         assert_eq!(rec, new_rec);
+    }
+
+    #[test]
+    fn can_write_multi_barcode_record() {
+        use crate::record::{MultiBarcodeReadRecord, MultiBarcodeRecordContext, MAX_INLINE_BARCODES};
+        use crate::collation::BarcodeRole;
+        use smallvec::{smallvec, SmallVec};
+
+        let rec = MultiBarcodeReadRecord {
+            barcodes: smallvec![42_u64, 12345_u64],
+            umi: 6789_u64,
+            dirs: vec![true, false, true],
+            refs: vec![100, 200, 300],
+        };
+
+        let ctx = MultiBarcodeRecordContext {
+            bc_types: smallvec![RadIntId::U32, RadIntId::U32],
+            umit: RadIntId::U32,
+            roles: smallvec![BarcodeRole::Sample, BarcodeRole::Cell],
+        };
+
+        let mut buf: Vec<u8> = Vec::new();
+        rec.write(&mut buf, &ctx).expect("couldn't write multi-barcode record");
+
+        let mut cursor = Cursor::new(buf);
+        let new_rec = MultiBarcodeReadRecord::from_bytes_with_context(&mut cursor, &ctx);
+
+        assert_eq!(rec, new_rec);
+    }
+
+    #[test]
+    fn multi_barcode_collation_key_is_last_barcode() {
+        use crate::record::{MultiBarcodeReadRecord, CollatableMappedRecord, HierarchicallyCollatable};
+        use smallvec::smallvec;
+
+        let rec = MultiBarcodeReadRecord {
+            barcodes: smallvec![42_u64, 12345_u64],
+            umi: 6789_u64,
+            dirs: vec![true],
+            refs: vec![100],
+        };
+
+        // collate_key() should return the last (cell) barcode
+        assert_eq!(rec.collate_key(), 12345_u64);
+
+        // level 0 = sample, level 1 = cell
+        assert_eq!(rec.collation_key_at_level(0), 42_u64);
+        assert_eq!(rec.collation_key_at_level(1), 12345_u64);
+        assert_eq!(rec.num_collation_levels(), 2);
     }
 }

--- a/libradicl/src/record.rs
+++ b/libradicl/src/record.rs
@@ -11,26 +11,25 @@
 //! traits for [MappedRecord]s and [RecordContext]s. It also defines concrete types
 //! implementing these traits for `alevin-fry` and `piscem-infer`.
 
+use crate::collation::BarcodeRole;
 use crate::io::{
-    NewI128, NewI16, NewI32, NewI64, NewI8, NewU128, NewU16, NewU32, NewU64, NewU8, TryWrapper,
+    NewI8, NewI16, NewI32, NewI64, NewI128, NewU8, NewU16, NewU32, NewU64, NewU128, TryWrapper,
 };
 use crate::{
     io as rad_io,
     rad_types::{
-        MappedFragmentOrientation, MappingType, PrimitiveInteger, RadIntId, RadType,
-        TagSection, TagValue,
+        MappedFragmentOrientation, MappingType, PrimitiveInteger, RadIntId, RadType, TagSection,
+        TagValue,
     },
-    utils
+    utils,
 };
-use crate::collation::BarcodeRole;
+use anyhow::{self, Context, bail};
+use bio_types::strand::{Same, Strand};
 use libradicl_macros::UmiTagged;
-use anyhow::{self, bail, Context};
-use bio_types::strand::{Strand, Same};
-use smallvec::SmallVec;
 use scroll::Pread;
+use smallvec::SmallVec;
 use std::io::{Read, Write};
 use std::mem;
-
 
 // Modified from https://stackoverflow.com/questions/69764050/how-to-get-the-indices-that-would-sort-a-vec
 // kmdreko
@@ -56,15 +55,15 @@ where
 /// Time: O(n), Space: O(n) for tracking visited indices.
 fn reorder_in_place<T>(data: &mut [T], indices: &[usize]) {
     let mut visited = vec![false; data.len()];
-    
+
     for start in 0..data.len() {
         if visited[start] {
             continue;
         }
-        
+
         let mut current = start;
         let mut next = indices[current];
-        
+
         while next != start {
             visited[current] = true;
             data.swap(current, next);
@@ -109,18 +108,21 @@ pub trait RecordHeader {
 }
 
 /// This trait specifies that a [RecordHeader] is collatable by some [B] which can be converted
-/// to a primitive integer.  For example, the header might be collatable by the barcode, and this 
-/// trait allows retriving that barcode / key as something convertible to an integer and also 
+/// to a primitive integer.  For example, the header might be collatable by the barcode, and this
+/// trait allows retriving that barcode / key as something convertible to an integer and also
 /// allows writing the header out to a stream.
-pub trait CollatableRecordHeader<B: ConvertiblePrimitiveInteger> : RecordHeader {
+pub trait CollatableRecordHeader<B: ConvertiblePrimitiveInteger>: RecordHeader {
     /// Retreives the key by which this record header (and the coresponding record) can be collated
     fn collate_key(&self) -> B;
     /// Writes the header to the provided `writer`.
-    fn write_fields<W: Write>(&self, writer: &mut W, _ctx: &<<Self as RecordHeader>::RecordType as MappedRecord>::ParsingContext) -> anyhow::Result<()>;
+    fn write_fields<W: Write>(
+        &self,
+        writer: &mut W,
+        _ctx: &<<Self as RecordHeader>::RecordType as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<()>;
 }
 
 // === standard alevin-fry reads
-
 
 /// Header information for an [AlevinFryReadRecord].
 /// note this header can be re-used for the record with position information
@@ -131,17 +133,25 @@ pub struct AlevinFryReadRecordHeader<B: ConvertiblePrimitiveInteger> {
     /// barcode
     pub bc: B,
     /// umi
-    pub umi: u64
+    pub umi: u64,
 }
 
 impl<B: ConvertiblePrimitiveInteger> RecordHeader for AlevinFryReadRecordHeader<B> {
     type RecordType = AlevinFryReadRecordT<B>;
-    fn naln(&self) -> u32 { self.naln }
+    fn naln(&self) -> u32 {
+        self.naln
+    }
 }
 
 impl<B: ConvertiblePrimitiveInteger> CollatableRecordHeader<B> for AlevinFryReadRecordHeader<B> {
-    fn collate_key(&self) -> B { self.bc }
-    fn write_fields<W: Write>(&self, writer: &mut W, ctx: &<<Self as RecordHeader>::RecordType as MappedRecord>::ParsingContext) -> anyhow::Result<()> {
+    fn collate_key(&self) -> B {
+        self.bc
+    }
+    fn write_fields<W: Write>(
+        &self,
+        writer: &mut W,
+        ctx: &<<Self as RecordHeader>::RecordType as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<()> {
         let na: u32 = self.naln();
         RadIntId::U32
             .write_to(na, writer)
@@ -156,25 +166,33 @@ impl<B: ConvertiblePrimitiveInteger> CollatableRecordHeader<B> for AlevinFryRead
     }
 }
 
-// === long reads 
+// === long reads
 
 /// Header information for an [ScLongReadRecord]; technically this could
-/// be suared with a regular [AlevinFryReadRecord], but it's kept separate 
+/// be suared with a regular [AlevinFryReadRecord], but it's kept separate
 /// for now in case the record format changes.
 pub struct ScLongReadRecordHeader<B: ConvertiblePrimitiveInteger> {
     pub naln: u32,
     pub bc: B,
-    pub umi: u64
+    pub umi: u64,
 }
 
 impl<B: ConvertiblePrimitiveInteger> RecordHeader for ScLongReadRecordHeader<B> {
     type RecordType = ScLongReadRecordT<B>;
-    fn naln(&self) -> u32 { self.naln }
+    fn naln(&self) -> u32 {
+        self.naln
+    }
 }
 
 impl<B: ConvertiblePrimitiveInteger> CollatableRecordHeader<B> for ScLongReadRecordHeader<B> {
-    fn collate_key(&self) -> B { self.bc }
-    fn write_fields<W: Write>(&self, writer: &mut W, ctx: &<<Self as RecordHeader>::RecordType as MappedRecord>::ParsingContext) -> anyhow::Result<()> {
+    fn collate_key(&self) -> B {
+        self.bc
+    }
+    fn write_fields<W: Write>(
+        &self,
+        writer: &mut W,
+        ctx: &<<Self as RecordHeader>::RecordType as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<()> {
         let na: u32 = self.naln();
         RadIntId::U32
             .write_to(na, writer)
@@ -194,17 +212,25 @@ impl<B: ConvertiblePrimitiveInteger> CollatableRecordHeader<B> for ScLongReadRec
 /// Header information for an [AtacSeqReadRecord]
 pub struct AtacSeqReadRecordHeader {
     pub naln: u32,
-    pub bc: u64
+    pub bc: u64,
 }
 
 impl RecordHeader for AtacSeqReadRecordHeader {
     type RecordType = AtacSeqReadRecord;
-    fn naln(&self) -> u32 { self.naln }
+    fn naln(&self) -> u32 {
+        self.naln
+    }
 }
 
 impl CollatableRecordHeader<u64> for AtacSeqReadRecordHeader {
-    fn collate_key(&self) -> u64 { self.bc }
-    fn write_fields<W: Write>(&self, writer: &mut W, ctx: &<<Self as RecordHeader>::RecordType as MappedRecord>::ParsingContext) -> anyhow::Result<()> {
+    fn collate_key(&self) -> u64 {
+        self.bc
+    }
+    fn write_fields<W: Write>(
+        &self,
+        writer: &mut W,
+        ctx: &<<Self as RecordHeader>::RecordType as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<()> {
         let na: u32 = self.naln();
         RadIntId::U32
             .write_to(na, writer)
@@ -228,33 +254,35 @@ pub trait CollatableRecord<B: ConvertiblePrimitiveInteger> : MappedRecord where
 }
 */
 
-
 // ====== bulk
 
 /// Header for a bulk RNA-seq read record
 #[allow(unused)]
 struct PiscemBulkReadRecordHeader {
-    pub na: u32
+    pub na: u32,
 }
 impl RecordHeader for PiscemBulkReadRecordHeader {
     type RecordType = PiscemBulkReadRecord;
-    fn naln(&self) -> u32 { self.na }
+    fn naln(&self) -> u32 {
+        self.na
+    }
 }
 
-// ====== generic 
+// ====== generic
 
 /// Header for a generic record type, the only guaranteed field is
 /// the number of alignments
 #[allow(unused)]
 struct GenericReadRecordHeader {
-    pub na: u32
+    pub na: u32,
 }
 
 impl RecordHeader for GenericReadRecordHeader {
     type RecordType = GenericReadRecord;
-    fn naln(&self) -> u32 { self.na }
+    fn naln(&self) -> u32 {
+        self.na
+    }
 }
-
 
 /// A concrete struct representing a [MappedRecord]
 /// that is as generic as possible. Here, the tags should
@@ -272,15 +300,37 @@ pub struct GenericReadRecord {
 }
 
 impl GenericReadRecord {
-    pub fn fmt_with_context(&self, ctx: &GenericReadRecordContext, f: &mut impl Write) -> std::io::Result<()> {
-        f.write_all(format!("GenericReadRecord{{ naln: {}, naln_tags: {},\nrtags: {},\natags:  {} }}\n", 
-                self.naln, 
+    pub fn fmt_with_context(
+        &self,
+        ctx: &GenericReadRecordContext,
+        f: &mut impl Write,
+    ) -> std::io::Result<()> {
+        f.write_all(
+            format!(
+                "GenericReadRecord{{ naln: {}, naln_tags: {},\nrtags: {},\natags:  {} }}\n",
+                self.naln,
                 self.naln_tags,
-                ctx.read_tags.iter_desc().zip(self.rtags.iter()).map( |(td, tv)| format!("{} : [{:?}]", td.name, tv)).collect::<Vec<_>>().join(", "),
-                self.atags.chunks_exact(self.naln_tags as usize).map( |vchunk| {
-                    ctx.aln_tags.iter_desc().zip(vchunk.iter()).map( |(td, tv)| format!("{} : [{:?}]", td.name, tv)).collect::<Vec<_>>().join(", ")
-                }).collect::<Vec<_>>().join("\n\t")
-        ).as_bytes())
+                ctx.read_tags
+                    .iter_desc()
+                    .zip(self.rtags.iter())
+                    .map(|(td, tv)| format!("{} : [{:?}]", td.name, tv))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                self.atags
+                    .chunks_exact(self.naln_tags as usize)
+                    .map(|vchunk| {
+                        ctx.aln_tags
+                            .iter_desc()
+                            .zip(vchunk.iter())
+                            .map(|(td, tv)| format!("{} : [{:?}]", td.name, tv))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n\t")
+            )
+            .as_bytes(),
+        )
     }
 }
 
@@ -291,16 +341,19 @@ pub struct GenericReadRecordContext {
     pub aln_tags: TagSection,
 }
 
-
-// ### Known size trait 
+// ### Known size trait
 
 pub trait KnownSize {
-    // returns the number of bytes taken for a record of the given type 
+    // returns the number of bytes taken for a record of the given type
     // with na alignments
-    fn nbytes(na: u32, ctx: &<Self as MappedRecord>::ParsingContext) -> usize where Self : MappedRecord;
+    fn nbytes(na: u32, ctx: &<Self as MappedRecord>::ParsingContext) -> usize
+    where
+        Self: MappedRecord;
 
     /// number of bytes for an individual alignment record
-    fn nbytes_aln(ctx: &<Self as MappedRecord>::ParsingContext) -> usize where Self : MappedRecord;
+    fn nbytes_aln(ctx: &<Self as MappedRecord>::ParsingContext) -> usize
+    where
+        Self: MappedRecord;
 }
 
 impl<B: ConvertiblePrimitiveInteger> KnownSize for AlevinFryReadRecordT<B> {
@@ -316,11 +369,10 @@ impl<B: ConvertiblePrimitiveInteger> KnownSize for AlevinFryReadRecordT<B> {
     }
 
     fn nbytes_aln(_ctx: &<Self as MappedRecord>::ParsingContext) -> usize {
-        // ori_ref 
+        // ori_ref
         std::mem::size_of::<u32>()
     }
 }
-
 
 impl<B: ConvertiblePrimitiveInteger> KnownSize for AlevinFryReadRecordWithPositionT<B> {
     fn nbytes(na: u32, ctx: &<Self as MappedRecord>::ParsingContext) -> usize {
@@ -335,7 +387,7 @@ impl<B: ConvertiblePrimitiveInteger> KnownSize for AlevinFryReadRecordWithPositi
     }
 
     fn nbytes_aln(_ctx: &<Self as MappedRecord>::ParsingContext) -> usize {
-        // ori_ref 
+        // ori_ref
         std::mem::size_of::<u32>()
         // position
         + std::mem::size_of::<u32>()
@@ -353,7 +405,7 @@ impl KnownSize for PiscemBulkReadRecord {
     }
 
     fn nbytes_aln(_ctx: &<Self as MappedRecord>::ParsingContext) -> usize {
-        // (mapped_fragment_orientation + reference): u32, 
+        // (mapped_fragment_orientation + reference): u32,
         // position: u32
         // frag length: u16
         std::mem::size_of::<u32>() + std::mem::size_of::<u32>() + std::mem::size_of::<u16>()
@@ -373,18 +425,17 @@ impl<B: ConvertiblePrimitiveInteger> KnownSize for ScLongReadRecordT<B> {
     }
 
     fn nbytes_aln(_ctx: &<Self as MappedRecord>::ParsingContext) -> usize {
-        // (ori_refernce): u32, 
-        std::mem::size_of::<u32>() 
-        // read_start : u32, 
-        + std::mem::size_of::<u32>() 
-        // read_end: u32, 
-        + std::mem::size_of::<u32>() 
-        // alignment_score: i32, 
-        + std::mem::size_of::<i32>() 
+        // (ori_refernce): u32,
+        std::mem::size_of::<u32>()
+        // read_start : u32,
+        + std::mem::size_of::<u32>()
+        // read_end: u32,
+        + std::mem::size_of::<u32>()
+        // alignment_score: i32,
+        + std::mem::size_of::<i32>()
         // tlen: u32 (NOTE: this should be moved to a file-level tag)
-        + std::mem::size_of::<u32>() 
+        + std::mem::size_of::<u32>()
     }
-
 }
 
 impl KnownSize for AtacSeqReadRecord {
@@ -398,11 +449,14 @@ impl KnownSize for AtacSeqReadRecord {
     }
 
     fn nbytes_aln(_ctx: &<Self as MappedRecord>::ParsingContext) -> usize {
-        // start_pos: u32, 
-        // ref: u32, 
-        // frag_len: u16, 
-        // map_type: u8, 
-        std::mem::size_of::<u32>() + std::mem::size_of::<u32>() + std::mem::size_of::<u16>() + std::mem::size_of::<u8>()
+        // start_pos: u32,
+        // ref: u32,
+        // frag_len: u16,
+        // map_type: u8,
+        std::mem::size_of::<u32>()
+            + std::mem::size_of::<u32>()
+            + std::mem::size_of::<u16>()
+            + std::mem::size_of::<u8>()
     }
 }
 
@@ -479,33 +533,40 @@ pub struct AtacSeqReadRecord {
     pub map_type: Vec<u8>,
 }
 
-pub trait CollatableMappedRecord<B: ConvertiblePrimitiveInteger> : MappedRecord where
+pub trait CollatableMappedRecord<B: ConvertiblePrimitiveInteger>: MappedRecord
+where
     // to help the trait solver
     <Self as CollatableMappedRecord<B>>::CollatableRecordHeader: RecordHeader,
-    <<Self as CollatableMappedRecord<B>>::CollatableRecordHeader as RecordHeader>::RecordType: MappedRecord<ParsingContext = Self::ParsingContext> {
-
+    <<Self as CollatableMappedRecord<B>>::CollatableRecordHeader as RecordHeader>::RecordType:
+        MappedRecord<ParsingContext = Self::ParsingContext>,
+{
     type CollatableRecordHeader: CollatableRecordHeader<B>;
-    /// Given a [RecordHeader] for this record (which has already been read and parsed), read 
-    /// a set of alignments for the record while retaining only those matching the prescribed 
+    /// Given a [RecordHeader] for this record (which has already been read and parsed), read
+    /// a set of alignments for the record while retaining only those matching the prescribed
     /// oreientation
-    fn from_bytes_with_header_retain_ori<T: Read>(reader: &mut T, hdr: &mut Self::CollatableRecordHeader, ctx: &<Self as MappedRecord>::ParsingContext, expected_ori: &MappedFragmentOrientation) -> Self;
+    fn from_bytes_with_header_retain_ori<T: Read>(
+        reader: &mut T,
+        hdr: &mut Self::CollatableRecordHeader,
+        ctx: &<Self as MappedRecord>::ParsingContext,
+        expected_ori: &MappedFragmentOrientation,
+    ) -> Self;
 
     /// set the key by which this record should be collated
     fn set_collate_key(&mut self, k: B);
-    
+
     /// get the key by which this record should be collated (e.g. call barcode)
     fn collate_key(&self) -> B;
 
     fn from_bytes_collatable_header<T: Read>(
         reader: &mut T,
-        context: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader>;
+        context: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader>;
 
     fn peek_collatable_header(
         reader: &[u8],
-        context: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader>;
-
+        context: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader>;
 }
-
 
 /// This trait represents a mapped read record that should be stored
 /// in the [crate::chunk::Chunk] of a RAD file.  The [crate::chunk::Chunk] type is parameterized on
@@ -541,15 +602,15 @@ pub trait MappedRecord {
     /// The number of alignments for this mapped record
     fn num_aln(&self) -> usize;
 
-    /// return a reference to the targets to which this 
+    /// return a reference to the targets to which this
     /// record aligns.
     fn refs(&self) -> &[u32];
 
     /// Returns true if this record has any alignment records occuring on the provided
     /// strand.
-    /// NOTE: 
+    /// NOTE:
     ///   - all alignments are compatible with an unknown strand
-    ///   - for paired-end mappings, this function looks for cases where read 1 matches the 
+    ///   - for paired-end mappings, this function looks for cases where read 1 matches the
     ///     provided strand
     fn has_alignment_on_strand(&self, s: Strand) -> bool;
 }
@@ -588,7 +649,7 @@ impl RecordContext for GenericReadRecordContext {
 
 /// context needed to read an alevin-fry record
 /// (the types of the barcode and umi)
-/// NOTE: This context is shared between the basic and positionally aware 
+/// NOTE: This context is shared between the basic and positionally aware
 /// AlevinFryReadRecord types
 #[derive(Debug, Clone)]
 pub struct AlevinFryRecordContext {
@@ -645,7 +706,9 @@ impl RecordContext for PiscemBulkRecordContext {
         if let RadType::Int(x) = frag_map_t {
             Ok(Self { frag_map_t: x })
         } else {
-            bail!("piscem bulk record context requries that \"frag_map_type\" tag is of type RadType::Int");
+            bail!(
+                "piscem bulk record context requries that \"frag_map_type\" tag is of type RadType::Int"
+            );
         }
     }
 }
@@ -654,34 +717,42 @@ impl MappedRecord for PiscemBulkReadRecord {
     type ParsingContext = PiscemBulkRecordContext;
     type PeekResult = Option<u64>;
 
-    fn is_empty(&self) -> bool { 
+    fn is_empty(&self) -> bool {
         self.refs.is_empty()
     }
 
     fn num_aln(&self) -> usize {
         self.refs.len()
     }
-    
+
     fn refs(&self) -> &[u32] {
         &self.refs
     }
- 
+
     fn has_alignment_on_strand(&self, s: Strand) -> bool {
-       match s {
+        match s {
             Strand::Unknown => !self.refs.is_empty(),
-            Strand::Forward => {
-                self.dirs.iter().any(|&x| 
-                    matches!(x, MappedFragmentOrientation::Forward | MappedFragmentOrientation::ForwardReverse | MappedFragmentOrientation::ForwardForward | MappedFragmentOrientation::Unknown )
+            Strand::Forward => self.dirs.iter().any(|&x| {
+                matches!(
+                    x,
+                    MappedFragmentOrientation::Forward
+                        | MappedFragmentOrientation::ForwardReverse
+                        | MappedFragmentOrientation::ForwardForward
+                        | MappedFragmentOrientation::Unknown
                 )
-            },
-            Strand::Reverse => {
-                self.dirs.iter().any(|&x| 
-                    matches!(x, MappedFragmentOrientation::Reverse | MappedFragmentOrientation::ReverseForward | MappedFragmentOrientation::ReverseReverse | MappedFragmentOrientation::Unknown )
+            }),
+            Strand::Reverse => self.dirs.iter().any(|&x| {
+                matches!(
+                    x,
+                    MappedFragmentOrientation::Reverse
+                        | MappedFragmentOrientation::ReverseForward
+                        | MappedFragmentOrientation::ReverseReverse
+                        | MappedFragmentOrientation::Unknown
                 )
-            }
-        } 
+            }),
+        }
     }
-    
+
     #[inline]
     fn from_bytes_with_context<T: Read>(reader: &mut T, ctx: &Self::ParsingContext) -> Self {
         const MASK_LOWER_30_BITS: u32 = 0xC0000000;
@@ -724,7 +795,9 @@ impl MappedRecord for PiscemBulkReadRecord {
 
     #[inline]
     fn peek_record(_buf: &[u8], _ctx: &Self::ParsingContext) -> Self::PeekResult {
-        unimplemented!("Currently there is no implementation for peek_record for PiscemBulkReadRecord. This should not be needed");
+        unimplemented!(
+            "Currently there is no implementation for peek_record for PiscemBulkReadRecord. This should not be needed"
+        );
     }
 
     #[inline]
@@ -762,37 +835,50 @@ impl MappedRecord for PiscemBulkReadRecord {
     }
 }
 
-impl<B:ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for AlevinFryReadRecordT<B> {
+impl<B: ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for AlevinFryReadRecordT<B> {
     type CollatableRecordHeader = AlevinFryReadRecordHeader<B>;
     #[inline]
-    fn from_bytes_with_header_retain_ori<T: Read>(reader: &mut T, hdr: &mut Self::CollatableRecordHeader, _ctx: &<Self as MappedRecord>::ParsingContext, expected_ori: &MappedFragmentOrientation) -> Self {
-        let rec = AlevinFryReadRecordT::<B>::from_bytes_with_header_keep_ori(reader, hdr.bc, hdr.umi, hdr.naln, expected_ori.into());
+    fn from_bytes_with_header_retain_ori<T: Read>(
+        reader: &mut T,
+        hdr: &mut Self::CollatableRecordHeader,
+        _ctx: &<Self as MappedRecord>::ParsingContext,
+        expected_ori: &MappedFragmentOrientation,
+    ) -> Self {
+        let rec = AlevinFryReadRecordT::<B>::from_bytes_with_header_keep_ori(
+            reader,
+            hdr.bc,
+            hdr.umi,
+            hdr.naln,
+            expected_ori.into(),
+        );
         hdr.naln = rec.refs.len() as u32;
         rec
     }
 
-    fn set_collate_key(&mut self, k: B) { self.bc = k; }
-    fn collate_key(&self) -> B { self.bc }
+    fn set_collate_key(&mut self, k: B) {
+        self.bc = k;
+    }
+    fn collate_key(&self) -> B {
+        self.bc
+    }
 
     fn from_bytes_collatable_header<T: Read>(
         reader: &mut T,
-        context: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader> {
+        context: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
         let mut rbuf = [0u8; 4];
         reader.read_exact(&mut rbuf).unwrap();
         let na = u32::from_le_bytes(rbuf);
         let bc = rad_io::read_into::<T, B>(reader, &context.bct);
         // NOTE: We likely will want to make the UMI generic as well
         let umi = rad_io::read_into_u64(reader, &context.umit);
-        Ok(Self::CollatableRecordHeader {
-            naln: na,
-            bc,
-            umi
-        })
+        Ok(Self::CollatableRecordHeader { naln: na, bc, umi })
     }
 
     fn peek_collatable_header(
         buf: &[u8],
-        ctx: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader> {
+        ctx: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
         let na_size = mem::size_of::<u32>();
         let bc_size = ctx.bct.bytes_for_type();
 
@@ -814,45 +900,56 @@ impl<B:ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for AlevinFryReadR
             RadIntId::U128 => panic!("u128 is currently not supported as a umi type"),
             _ => panic!("signed umi integer encodings are not supported"),
         };
-        Ok(Self::CollatableRecordHeader {
-            naln: na,
-            bc,
-            umi
-        })
+        Ok(Self::CollatableRecordHeader { naln: na, bc, umi })
     }
 }
 
-impl<B:ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for AlevinFryReadRecordWithPositionT<B> {
+impl<B: ConvertiblePrimitiveInteger> CollatableMappedRecord<B>
+    for AlevinFryReadRecordWithPositionT<B>
+{
     type CollatableRecordHeader = AlevinFryReadRecordHeader<B>;
     #[inline]
-    fn from_bytes_with_header_retain_ori<T: Read>(reader: &mut T, hdr: &mut Self::CollatableRecordHeader, _ctx: &<Self as MappedRecord>::ParsingContext, expected_ori: &MappedFragmentOrientation) -> Self {
-        let rec = AlevinFryReadRecordWithPositionT::<B>::from_bytes_with_header_keep_ori(reader, hdr.bc, hdr.umi, hdr.naln, expected_ori.into());
+    fn from_bytes_with_header_retain_ori<T: Read>(
+        reader: &mut T,
+        hdr: &mut Self::CollatableRecordHeader,
+        _ctx: &<Self as MappedRecord>::ParsingContext,
+        expected_ori: &MappedFragmentOrientation,
+    ) -> Self {
+        let rec = AlevinFryReadRecordWithPositionT::<B>::from_bytes_with_header_keep_ori(
+            reader,
+            hdr.bc,
+            hdr.umi,
+            hdr.naln,
+            expected_ori.into(),
+        );
         hdr.naln = rec.refs.len() as u32;
         rec
     }
 
-    fn set_collate_key(&mut self, k: B) { self.bc = k; }
-    fn collate_key(&self) -> B { self.bc }
+    fn set_collate_key(&mut self, k: B) {
+        self.bc = k;
+    }
+    fn collate_key(&self) -> B {
+        self.bc
+    }
 
     fn from_bytes_collatable_header<T: Read>(
         reader: &mut T,
-        context: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader> {
+        context: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
         let mut rbuf = [0u8; 4];
         reader.read_exact(&mut rbuf).unwrap();
         let na = u32::from_le_bytes(rbuf);
         let bc = rad_io::read_into::<T, B>(reader, &context.bct);
         // NOTE: We likely will want to make the UMI generic as well
         let umi = rad_io::read_into_u64(reader, &context.umit);
-        Ok(Self::CollatableRecordHeader {
-            naln: na,
-            bc,
-            umi
-        })
+        Ok(Self::CollatableRecordHeader { naln: na, bc, umi })
     }
 
     fn peek_collatable_header(
         buf: &[u8],
-        ctx: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader> {
+        ctx: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
         let na_size = mem::size_of::<u32>();
         let bc_size = ctx.bct.bytes_for_type();
 
@@ -874,14 +971,9 @@ impl<B:ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for AlevinFryReadR
             RadIntId::U128 => panic!("u128 is currently not supported as a umi type"),
             _ => panic!("signed umi integer encodings are not supported"),
         };
-        Ok(Self::CollatableRecordHeader {
-            naln: na,
-            bc,
-            umi
-        })
+        Ok(Self::CollatableRecordHeader { naln: na, bc, umi })
     }
 }
-
 
 impl<B: ConvertiblePrimitiveInteger> MappedRecord for AlevinFryReadRecordT<B> {
     type ParsingContext = AlevinFryRecordContext;
@@ -902,17 +994,12 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for AlevinFryReadRecordT<B> {
     }
 
     fn has_alignment_on_strand(&self, s: Strand) -> bool {
-       match s {
+        match s {
             Strand::Unknown => !self.refs.is_empty(),
-            Strand::Forward => {
-                self.dirs.iter().any(|&x| x)
-            },
-            Strand::Reverse => {
-                self.dirs.iter().any(|&x| !x)
-            }
-        } 
+            Strand::Forward => self.dirs.iter().any(|&x| x),
+            Strand::Reverse => self.dirs.iter().any(|&x| !x),
+        }
     }
-
 
     #[inline]
     fn peek_record(buf: &[u8], ctx: &Self::ParsingContext) -> Self::PeekResult {
@@ -939,7 +1026,6 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for AlevinFryReadRecordT<B> {
         };
         (bc, umi)
     }
-
 
     #[inline]
     fn from_bytes_with_context<T: Read>(reader: &mut T, ctx: &Self::ParsingContext) -> Self {
@@ -979,7 +1065,9 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for AlevinFryReadRecordT<B> {
 
         // if we don't have orientations (because of filtering) then just pretend they are false
         let dir_iter = self.dirs.iter();
-        for (dir, ref_idx) in itertools::izip!(dir_iter.chain(std::iter::repeat(&false)), &self.refs) {
+        for (dir, ref_idx) in
+            itertools::izip!(dir_iter.chain(std::iter::repeat(&false)), &self.refs)
+        {
             let encoded_dir: u32 = if *dir { 1_u32 << 31 } else { 0_u32 };
             let encoded_dir_ref: u32 = ref_idx | encoded_dir;
             writer
@@ -1009,17 +1097,12 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for AlevinFryReadRecordWithPos
     }
 
     fn has_alignment_on_strand(&self, s: Strand) -> bool {
-       match s {
+        match s {
             Strand::Unknown => !self.refs.is_empty(),
-            Strand::Forward => {
-                self.dirs.iter().any(|&x| x)
-            },
-            Strand::Reverse => {
-                self.dirs.iter().any(|&x| !x)
-            }
-        } 
+            Strand::Forward => self.dirs.iter().any(|&x| x),
+            Strand::Reverse => self.dirs.iter().any(|&x| !x),
+        }
     }
-
 
     #[inline]
     fn peek_record(buf: &[u8], ctx: &Self::ParsingContext) -> Self::PeekResult {
@@ -1046,7 +1129,6 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for AlevinFryReadRecordWithPos
         };
         (bc, umi)
     }
-
 
     #[inline]
     fn from_bytes_with_context<T: Read>(reader: &mut T, ctx: &Self::ParsingContext) -> Self {
@@ -1089,7 +1171,11 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for AlevinFryReadRecordWithPos
 
         // if we don't have orientations (because of filtering) then just pretend they are false
         let dir_iter = self.dirs.iter();
-        for (dir, ref_idx, pos) in itertools::izip!(dir_iter.chain(std::iter::repeat(&false)), &self.refs, &self.pos) {
+        for (dir, ref_idx, pos) in itertools::izip!(
+            dir_iter.chain(std::iter::repeat(&false)),
+            &self.refs,
+            &self.pos
+        ) {
             let encoded_dir: u32 = if *dir { 1_u32 << 31 } else { 0_u32 };
             let encoded_dir_ref: u32 = ref_idx | encoded_dir;
             writer
@@ -1118,7 +1204,7 @@ impl MappedRecord for GenericReadRecord {
     fn has_alignment_on_strand(&self, _s: Strand) -> bool {
         unimplemented!("no implementation of has_alignment_on_strand for GenericReadRecord")
     }
- 
+
     fn refs(&self) -> &[u32] {
         unimplemented!("no implementation of refs() for GenericReadRecord yet")
     }
@@ -1191,10 +1277,11 @@ impl MappedRecord for GenericReadRecord {
     }
     */
 
-
     #[inline]
     fn peek_record(_buf: &[u8], _ctx: &Self::ParsingContext) -> Self::PeekResult {
-        unimplemented!("Currently there is no implementation for peek_record for GenericRecord. This should not be needed");
+        unimplemented!(
+            "Currently there is no implementation for peek_record for GenericRecord. This should not be needed"
+        );
     }
 
     #[inline]
@@ -1289,33 +1376,31 @@ pub trait ConvertiblePrimitiveInteger:
 }
 
 impl<
-        T: PrimitiveInteger
-            + std::convert::From<NewU8>
-            + std::convert::From<NewU16>
-            + std::convert::From<NewU32>
-            + std::convert::From<NewU64>
-            + std::convert::From<NewU128>
-            + std::convert::TryFrom<TryWrapper<NewU8>>
-            + std::convert::TryFrom<TryWrapper<NewU16>>
-            + std::convert::TryFrom<TryWrapper<NewU32>>
-            + std::convert::TryFrom<TryWrapper<NewU64>>
-            + std::convert::TryFrom<TryWrapper<NewU128>>
-            + std::convert::From<NewI8>
-            + std::convert::From<NewI16>
-            + std::convert::From<NewI32>
-            + std::convert::From<NewI64>
-            + std::convert::From<NewI128>
-            + std::convert::TryFrom<TryWrapper<NewI8>>
-            + std::convert::TryFrom<TryWrapper<NewI16>>
-            + std::convert::TryFrom<TryWrapper<NewI32>>
-            + std::convert::TryFrom<TryWrapper<NewI64>>
-            + std::convert::TryFrom<TryWrapper<NewI128>>
-            + std::convert::TryFrom<TryWrapper<NewI128>>,
-    > ConvertiblePrimitiveInteger for T
+    T: PrimitiveInteger
+        + std::convert::From<NewU8>
+        + std::convert::From<NewU16>
+        + std::convert::From<NewU32>
+        + std::convert::From<NewU64>
+        + std::convert::From<NewU128>
+        + std::convert::TryFrom<TryWrapper<NewU8>>
+        + std::convert::TryFrom<TryWrapper<NewU16>>
+        + std::convert::TryFrom<TryWrapper<NewU32>>
+        + std::convert::TryFrom<TryWrapper<NewU64>>
+        + std::convert::TryFrom<TryWrapper<NewU128>>
+        + std::convert::From<NewI8>
+        + std::convert::From<NewI16>
+        + std::convert::From<NewI32>
+        + std::convert::From<NewI64>
+        + std::convert::From<NewI128>
+        + std::convert::TryFrom<TryWrapper<NewI8>>
+        + std::convert::TryFrom<TryWrapper<NewI16>>
+        + std::convert::TryFrom<TryWrapper<NewI32>>
+        + std::convert::TryFrom<TryWrapper<NewI64>>
+        + std::convert::TryFrom<TryWrapper<NewI128>>
+        + std::convert::TryFrom<TryWrapper<NewI128>>,
+> ConvertiblePrimitiveInteger for T
 {
 }
-
-
 
 impl<B: ConvertiblePrimitiveInteger> AlevinFryReadRecordT<B> {
     /// Obtains the next [AlevinFryReadRecord] in the stream from the reader `reader`.
@@ -1534,7 +1619,6 @@ impl<B: ConvertiblePrimitiveInteger> AlevinFryReadRecordWithPositionT<B> {
     }
 }
 
-
 #[derive(Debug, Clone)]
 pub struct AtacSeqRecordContext {
     pub bct: RadIntId,
@@ -1572,20 +1656,19 @@ impl CollatableMappedRecord<u64> for AtacSeqReadRecord {
     type CollatableRecordHeader = AtacSeqReadRecordHeader;
     fn from_bytes_collatable_header<T: Read>(
         reader: &mut T,
-        context: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader> {
+        context: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
         let mut rbuf = [0u8; 4];
         reader.read_exact(&mut rbuf).unwrap();
         let na = u32::from_le_bytes(rbuf);
         let bc = rad_io::read_into_u64(reader, &context.bct);
-        Ok(Self::CollatableRecordHeader {
-            naln: na,
-            bc,
-        })
+        Ok(Self::CollatableRecordHeader { naln: na, bc })
     }
 
     fn peek_collatable_header(
         buf: &[u8],
-        ctx: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader> {
+        ctx: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
         let na_size = mem::size_of::<u32>();
 
         let na = buf.pread::<u32>(0).unwrap();
@@ -1598,19 +1681,23 @@ impl CollatableMappedRecord<u64> for AtacSeqReadRecord {
             RadIntId::U128 => NewU128(buf.pread::<u128>(na_size).unwrap()).into(),
             _ => panic!("signed barcode integer encodings are not supported"),
         };
-        Ok(Self::CollatableRecordHeader {
-            naln: na,
-            bc,
-        })
+        Ok(Self::CollatableRecordHeader { naln: na, bc })
     }
 
     fn set_collate_key(&mut self, k: u64) {
         self.bc = k;
     }
-    fn collate_key(&self) -> u64 { self.bc }
+    fn collate_key(&self) -> u64 {
+        self.bc
+    }
 
     #[inline]
-    fn from_bytes_with_header_retain_ori<T: Read>(reader: &mut T, hdr: &mut Self::CollatableRecordHeader, _ctx: &<Self as MappedRecord>::ParsingContext, _expected_ori: &MappedFragmentOrientation) -> Self {
+    fn from_bytes_with_header_retain_ori<T: Read>(
+        reader: &mut T,
+        hdr: &mut Self::CollatableRecordHeader,
+        _ctx: &<Self as MappedRecord>::ParsingContext,
+        _expected_ori: &MappedFragmentOrientation,
+    ) -> Self {
         // NOTE: No orientation recorded for ATACSeq records, so everything is retained
         let mut rbuf = [0u8; 255];
         let na = hdr.naln;
@@ -1657,14 +1744,16 @@ impl MappedRecord for AtacSeqReadRecord {
         self.refs.is_empty()
     }
 
-    fn num_aln(&self) -> usize { self.refs.len() }
+    fn num_aln(&self) -> usize {
+        self.refs.len()
+    }
 
     fn has_alignment_on_strand(&self, _s: Strand) -> bool {
-        // we don't record the orientation, so right now 
+        // we don't record the orientation, so right now
         // treat everything as compatible
         !self.refs.is_empty()
     }
- 
+
     fn refs(&self) -> &[u32] {
         &self.refs
     }
@@ -1780,10 +1869,7 @@ impl MappedRecord for AtacSeqReadRecord {
     }
 }
 
-
-
 impl AtacSeqReadRecord {
-
     /// Obtains the next [AtacSeqReadRecord] in the stream from the reader `reader`.
     /// The barcode should be encoded with the [RadIntId] type `bct` and
     pub fn from_bytes<T: Read>(reader: &mut T, bct: &RadIntId) -> Self {
@@ -1906,23 +1992,21 @@ impl<B: ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for ScLongReadRec
     type CollatableRecordHeader = ScLongReadRecordHeader<B>;
     fn from_bytes_collatable_header<T: Read>(
         reader: &mut T,
-        context: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader> {
+        context: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
         let mut rbuf = [0u8; 4];
         reader.read_exact(&mut rbuf).unwrap();
         let na = u32::from_le_bytes(rbuf);
         let bc = rad_io::read_into::<T, B>(reader, &context.bct);
         // NOTE: We likely will want to make the UMI generic as well
         let umi = rad_io::read_into_u64(reader, &context.umit);
-        Ok(Self::CollatableRecordHeader {
-            naln: na,
-            bc,
-            umi
-        })
+        Ok(Self::CollatableRecordHeader { naln: na, bc, umi })
     }
 
     fn peek_collatable_header(
         buf: &[u8],
-        ctx: &<Self as MappedRecord>::ParsingContext) -> anyhow::Result<Self::CollatableRecordHeader> {
+        ctx: &<Self as MappedRecord>::ParsingContext,
+    ) -> anyhow::Result<Self::CollatableRecordHeader> {
         let na_size = mem::size_of::<u32>();
         let bc_size = ctx.bct.bytes_for_type();
 
@@ -1944,21 +2028,23 @@ impl<B: ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for ScLongReadRec
             RadIntId::U128 => panic!("u128 is currently not supported as a umi type"),
             _ => panic!("signed umi integer encodings are not supported"),
         };
-        Ok(Self::CollatableRecordHeader {
-            naln: na,
-            bc,
-            umi
-        })
+        Ok(Self::CollatableRecordHeader { naln: na, bc, umi })
     }
 
     fn set_collate_key(&mut self, k: B) {
         self.bc = k;
     }
-    fn collate_key(&self) -> B { self.bc }
-
+    fn collate_key(&self) -> B {
+        self.bc
+    }
 
     #[inline]
-    fn from_bytes_with_header_retain_ori<T: Read>(reader: &mut T, hdr: &mut Self::CollatableRecordHeader, _ctx: &<Self as MappedRecord>::ParsingContext, expected_ori: &MappedFragmentOrientation) -> Self {
+    fn from_bytes_with_header_retain_ori<T: Read>(
+        reader: &mut T,
+        hdr: &mut Self::CollatableRecordHeader,
+        _ctx: &<Self as MappedRecord>::ParsingContext,
+        expected_ori: &MappedFragmentOrientation,
+    ) -> Self {
         let na = hdr.naln;
         let bc = hdr.bc;
         let umi = hdr.umi;
@@ -2003,7 +2089,8 @@ impl<B: ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for ScLongReadRec
                 Strand::Forward
             } else {
                 Strand::Reverse
-            }.into();
+            }
+            .into();
 
             if expected_ori.same(&strand) || expected_ori.is_unknown() {
                 rec.dirs.push(dir);
@@ -2012,10 +2099,10 @@ impl<B: ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for ScLongReadRec
                 rec.starts.push(start);
                 rec.ends.push(end);
                 rec.tlens.push(tlen);
-            } 
+            }
         }
         hdr.naln = rec.refs.len() as u32;
-        // sort all fields by ref 
+        // sort all fields by ref
         let indices = argsort(&rec.refs);
         reorder_in_place(&mut rec.dirs, &indices);
         reorder_in_place(&mut rec.refs, &indices);
@@ -2036,7 +2123,7 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for ScLongReadRecordT<B> {
     fn is_empty(&self) -> bool {
         self.refs.is_empty()
     }
-   
+
     fn num_aln(&self) -> usize {
         self.refs.len()
     }
@@ -2046,15 +2133,11 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for ScLongReadRecordT<B> {
     }
 
     fn has_alignment_on_strand(&self, s: Strand) -> bool {
-       match s {
+        match s {
             Strand::Unknown => !self.refs.is_empty(),
-            Strand::Forward => {
-                self.dirs.iter().any(|&x| x)
-            },
-            Strand::Reverse => {
-                self.dirs.iter().any(|&x| !x)
-            }
-        } 
+            Strand::Forward => self.dirs.iter().any(|&x| x),
+            Strand::Reverse => self.dirs.iter().any(|&x| !x),
+        }
     }
 
     #[inline]
@@ -2174,9 +2257,6 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for ScLongReadRecordT<B> {
     }
 }
 
-
-
-
 impl<B: ConvertiblePrimitiveInteger> ScLongReadRecordT<B> {
     /// Obtains the next [ScLongReadRecord] in the stream from the reader `reader`.
     /// The barcode should be encoded with the [RadIntId] type `bct` and
@@ -2201,9 +2281,7 @@ impl<B: ConvertiblePrimitiveInteger> ScLongReadRecordT<B> {
     }
 
     pub fn from_bytes_with_header<T: Read>(_reader: &mut T, _bc: u64, _umi: u64, _na: u32) -> Self {
-        unimplemented!(
-            "from_bytes_with_header is not implemented for ScLongReadRecordT"
-        );
+        unimplemented!("from_bytes_with_header is not implemented for ScLongReadRecordT");
     }
 }
 
@@ -2271,7 +2349,9 @@ impl RecordContext for MultiBarcodeRecordContext {
                 count += 1;
             }
             if count == 0 {
-                bail!("multi-barcode record context: num_barcodes file tag present but no bN read-level tags found");
+                bail!(
+                    "multi-barcode record context: num_barcodes file tag present but no bN read-level tags found"
+                );
             }
             count
         } else {
@@ -2281,12 +2361,19 @@ impl RecordContext for MultiBarcodeRecordContext {
         let mut bc_types = SmallVec::new();
         for i in 0..num_barcodes {
             let tag_name = format!("b{}", i);
-            let bct = rt.get_tag_type(&tag_name)
-                .ok_or_else(|| anyhow::anyhow!("multi-barcode record context requires a '{}' read-level tag", tag_name))?;
+            let bct = rt.get_tag_type(&tag_name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "multi-barcode record context requires a '{}' read-level tag",
+                    tag_name
+                )
+            })?;
             if let RadType::Int(x) = bct {
                 bc_types.push(x);
             } else {
-                bail!("multi-barcode record context requires that '{}' tag is of type RadType::Int", tag_name);
+                bail!(
+                    "multi-barcode record context requires that '{}' tag is of type RadType::Int",
+                    tag_name
+                );
             }
         }
 
@@ -2317,7 +2404,11 @@ impl MultiBarcodeRecordContext {
         umit: RadIntId,
         roles: SmallVec<[BarcodeRole; MAX_INLINE_BARCODES]>,
     ) -> Self {
-        Self { bc_types, umit, roles }
+        Self {
+            bc_types,
+            umit,
+            roles,
+        }
     }
 
     /// Number of barcode levels in this context.
@@ -2368,7 +2459,10 @@ impl<B: ConvertiblePrimitiveInteger> CollatableRecordHeader<B> for MultiBarcodeR
     /// Returns the innermost (last) barcode as the collation key,
     /// which is typically the cell barcode.
     fn collate_key(&self) -> B {
-        *self.barcodes.last().expect("multi-barcode header must have at least one barcode")
+        *self
+            .barcodes
+            .last()
+            .expect("multi-barcode header must have at least one barcode")
     }
 
     fn write_fields<W: Write>(
@@ -2520,7 +2614,9 @@ impl<B: ConvertiblePrimitiveInteger> MappedRecord for MultiBarcodeReadRecordT<B>
 
         // Write alignment records
         let dir_iter = self.dirs.iter();
-        for (dir, ref_idx) in itertools::izip!(dir_iter.chain(std::iter::repeat(&false)), &self.refs) {
+        for (dir, ref_idx) in
+            itertools::izip!(dir_iter.chain(std::iter::repeat(&false)), &self.refs)
+        {
             let encoded_dir: u32 = if *dir { 1_u32 << 31 } else { 0_u32 };
             let encoded_dir_ref: u32 = ref_idx | encoded_dir;
             writer
@@ -2560,7 +2656,10 @@ impl<B: ConvertiblePrimitiveInteger> CollatableMappedRecord<B> for MultiBarcodeR
     }
 
     fn collate_key(&self) -> B {
-        *self.barcodes.last().expect("multi-barcode record must have at least one barcode")
+        *self
+            .barcodes
+            .last()
+            .expect("multi-barcode record must have at least one barcode")
     }
 
     fn from_bytes_collatable_header<T: Read>(
@@ -2769,9 +2868,9 @@ mod tests {
 
     #[test]
     fn can_write_multi_barcode_record() {
-        use crate::record::{MultiBarcodeReadRecord, MultiBarcodeRecordContext, MAX_INLINE_BARCODES};
         use crate::collation::BarcodeRole;
-        use smallvec::{smallvec, SmallVec};
+        use crate::record::{MultiBarcodeReadRecord, MultiBarcodeRecordContext};
+        use smallvec::smallvec;
 
         let rec = MultiBarcodeReadRecord {
             barcodes: smallvec![42_u64, 12345_u64],
@@ -2787,7 +2886,8 @@ mod tests {
         };
 
         let mut buf: Vec<u8> = Vec::new();
-        rec.write(&mut buf, &ctx).expect("couldn't write multi-barcode record");
+        rec.write(&mut buf, &ctx)
+            .expect("couldn't write multi-barcode record");
 
         let mut cursor = Cursor::new(buf);
         let new_rec = MultiBarcodeReadRecord::from_bytes_with_context(&mut cursor, &ctx);
@@ -2797,7 +2897,9 @@ mod tests {
 
     #[test]
     fn multi_barcode_collation_key_is_last_barcode() {
-        use crate::record::{MultiBarcodeReadRecord, CollatableMappedRecord, HierarchicallyCollatable};
+        use crate::record::{
+            CollatableMappedRecord, HierarchicallyCollatable, MultiBarcodeReadRecord,
+        };
         use smallvec::smallvec;
 
         let rec = MultiBarcodeReadRecord {

--- a/libradicl/src/schema.rs
+++ b/libradicl/src/schema.rs
@@ -31,5 +31,5 @@ pub struct ProtocolInfo {
 
 pub enum CollateKey<'a> {
     Barcode,
-    Pos(Box<dyn Fn(u32, usize) -> usize + 'a>)
+    Pos(Box<dyn Fn(u32, usize) -> usize + 'a>),
 }

--- a/libradicl/src/unmapped.rs
+++ b/libradicl/src/unmapped.rs
@@ -221,6 +221,172 @@ impl UnmappedBcRecordReader {
     }
 }
 
+// ---------------------------------------------------------------------------
+// CollatedUnmappedCounts — in-memory representation with on-disk serialization
+// ---------------------------------------------------------------------------
+
+/// Collated (corrected) unmapped barcode frequency map.
+///
+/// Two variants for zero-overhead on the common single-barcode path:
+/// - `Single`: keyed by cell barcode (u64). Identical to pre-multi-barcode behavior.
+/// - `Multi`: keyed by (sample_bc, cell_bc) for per-sample accuracy.
+///
+/// On disk, both variants use the self-describing format (header + records).
+/// The variant is determined by the header's `num_fields`.
+pub enum CollatedUnmappedCounts {
+    /// Single barcode — lookup by cell BC.
+    Single {
+        counts: std::collections::HashMap<u64, u32>,
+        bc_type: RadIntId,
+    },
+    /// Multiple barcodes — lookup by (sample_bc, cell_bc) tuple.
+    Multi {
+        counts: std::collections::HashMap<(u64, u64), u32>,
+        field_types: Vec<RadIntId>,
+    },
+}
+
+impl CollatedUnmappedCounts {
+    /// Create an empty single-barcode map.
+    pub fn new_single(bc_type: RadIntId) -> Self {
+        CollatedUnmappedCounts::Single {
+            counts: std::collections::HashMap::new(),
+            bc_type,
+        }
+    }
+
+    /// Create an empty multi-barcode map.
+    pub fn new_multi(field_types: Vec<RadIntId>) -> Self {
+        CollatedUnmappedCounts::Multi {
+            counts: std::collections::HashMap::new(),
+            field_types,
+        }
+    }
+
+    /// Look up unmapped count by cell barcode (single-barcode path).
+    pub fn get_single(&self, cell_bc: u64) -> u32 {
+        match self {
+            CollatedUnmappedCounts::Single { counts, .. } => {
+                counts.get(&cell_bc).copied().unwrap_or(0)
+            }
+            // Fallback: if called on Multi, sum across all samples for this cell
+            CollatedUnmappedCounts::Multi { counts, .. } => {
+                counts
+                    .iter()
+                    .filter(|((_, cb), _)| *cb == cell_bc)
+                    .map(|(_, &c)| c)
+                    .sum()
+            }
+        }
+    }
+
+    /// Look up unmapped count by (sample_bc, cell_bc) pair (multi-barcode path).
+    pub fn get_multi(&self, sample_bc: u64, cell_bc: u64) -> u32 {
+        match self {
+            CollatedUnmappedCounts::Multi { counts, .. } => {
+                counts.get(&(sample_bc, cell_bc)).copied().unwrap_or(0)
+            }
+            // Fallback: if called on Single, just use cell_bc
+            CollatedUnmappedCounts::Single { counts, .. } => {
+                counts.get(&cell_bc).copied().unwrap_or(0)
+            }
+        }
+    }
+
+    /// Insert or add a count for a single-barcode key.
+    pub fn insert_single(&mut self, cell_bc: u64, count: u32) {
+        if let CollatedUnmappedCounts::Single { counts, .. } = self {
+            *counts.entry(cell_bc).or_insert(0) += count;
+        }
+    }
+
+    /// Insert or add a count for a multi-barcode key.
+    pub fn insert_multi(&mut self, sample_bc: u64, cell_bc: u64, count: u32) {
+        if let CollatedUnmappedCounts::Multi { counts, .. } = self {
+            *counts.entry((sample_bc, cell_bc)).or_insert(0) += count;
+        }
+    }
+
+    /// Whether this is a multi-barcode map.
+    pub fn is_multi(&self) -> bool {
+        matches!(self, CollatedUnmappedCounts::Multi { .. })
+    }
+
+    /// Write to the self-describing on-disk format.
+    pub fn write_to<W: Write>(&self, writer: &mut W) -> anyhow::Result<()> {
+        match self {
+            CollatedUnmappedCounts::Single { counts, bc_type } => {
+                let fmt = UnmappedBcFormat::single(*bc_type);
+                fmt.write_header(writer)?;
+                let mut rec_writer = UnmappedBcRecordWriter::new(fmt);
+                for (&bc, &count) in counts {
+                    rec_writer.write_record(&[bc], count);
+                }
+                rec_writer.flush_to(writer)?;
+            }
+            CollatedUnmappedCounts::Multi { counts, field_types } => {
+                let fmt = UnmappedBcFormat::multi(field_types.clone());
+                fmt.write_header(writer)?;
+                let mut rec_writer = UnmappedBcRecordWriter::new(fmt);
+                for (&(sample_bc, cell_bc), &count) in counts {
+                    rec_writer.write_record(&[sample_bc, cell_bc], count);
+                }
+                rec_writer.flush_to(writer)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Read from the self-describing on-disk format.
+    pub fn read_from<R: Read>(reader: &mut R) -> anyhow::Result<Self> {
+        let format = match UnmappedBcFormat::read_header(reader)? {
+            Some(fmt) => fmt,
+            None => {
+                // Empty file — return empty single-barcode map
+                return Ok(CollatedUnmappedCounts::new_single(RadIntId::U32));
+            }
+        };
+
+        let mut rec_reader = UnmappedBcRecordReader::new(format.clone());
+
+        if format.num_fields() == 1 {
+            let mut counts = std::collections::HashMap::new();
+            while let Some((bcs, count)) = rec_reader.read_record(reader)? {
+                *counts.entry(bcs[0]).or_insert(0) += count;
+            }
+            Ok(CollatedUnmappedCounts::Single {
+                counts,
+                bc_type: format.field_types[0],
+            })
+        } else {
+            let mut counts = std::collections::HashMap::new();
+            while let Some((bcs, count)) = rec_reader.read_record(reader)? {
+                let sample_bc = bcs[0];
+                let cell_bc = *bcs.last().unwrap_or(&0);
+                *counts.entry((sample_bc, cell_bc)).or_insert(0) += count;
+            }
+            Ok(CollatedUnmappedCounts::Multi {
+                counts,
+                field_types: format.field_types,
+            })
+        }
+    }
+
+    /// Write to a file path.
+    pub fn write_to_file(&self, path: &std::path::Path) -> anyhow::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let mut writer = std::io::BufWriter::new(file);
+        self.write_to(&mut writer)
+    }
+
+    /// Read from a file path.
+    pub fn read_from_file(path: &std::path::Path) -> anyhow::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let mut reader = std::io::BufReader::new(file);
+        Self::read_from(&mut reader)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -285,5 +451,49 @@ mod tests {
         let cursor = Cursor::new(Vec::<u8>::new());
         let result = UnmappedBcFormat::read_header(&mut cursor.clone()).unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn collated_single_roundtrip() {
+        let mut counts = CollatedUnmappedCounts::new_single(RadIntId::U32);
+        counts.insert_single(100, 5);
+        counts.insert_single(200, 10);
+        counts.insert_single(100, 3); // should add to existing
+
+        assert_eq!(counts.get_single(100), 8);
+        assert_eq!(counts.get_single(200), 10);
+        assert_eq!(counts.get_single(999), 0);
+
+        // Roundtrip
+        let mut buf = Vec::new();
+        counts.write_to(&mut buf).unwrap();
+
+        let restored = CollatedUnmappedCounts::read_from(&mut Cursor::new(&buf)).unwrap();
+        assert!(!restored.is_multi());
+        assert_eq!(restored.get_single(100), 8);
+        assert_eq!(restored.get_single(200), 10);
+    }
+
+    #[test]
+    fn collated_multi_roundtrip() {
+        let mut counts = CollatedUnmappedCounts::new_multi(vec![RadIntId::U16, RadIntId::U32]);
+        counts.insert_multi(1, 100, 5);   // sample 1, cell 100
+        counts.insert_multi(2, 100, 10);  // sample 2, cell 100 (different sample!)
+        counts.insert_multi(1, 200, 3);
+
+        assert_eq!(counts.get_multi(1, 100), 5);
+        assert_eq!(counts.get_multi(2, 100), 10);
+        assert_eq!(counts.get_multi(1, 200), 3);
+        assert_eq!(counts.get_multi(1, 999), 0);
+
+        // Roundtrip
+        let mut buf = Vec::new();
+        counts.write_to(&mut buf).unwrap();
+
+        let restored = CollatedUnmappedCounts::read_from(&mut Cursor::new(&buf)).unwrap();
+        assert!(restored.is_multi());
+        assert_eq!(restored.get_multi(1, 100), 5);
+        assert_eq!(restored.get_multi(2, 100), 10);
+        assert_eq!(restored.get_multi(1, 200), 3);
     }
 }

--- a/libradicl/src/unmapped.rs
+++ b/libradicl/src/unmapped.rs
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2020-2024 COMBINE-lab.
+ *
+ * This file is part of libradicl
+ * (see https://www.github.com/COMBINE-lab/libradicl).
+ *
+ * License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause
+ */
+
+//! Self-describing file format for unmapped barcode counts.
+//!
+//! Supports arbitrary numbers of barcode fields with per-field widths
+//! matching `RadIntId`. Both single-barcode (standard 10x) and
+//! multi-barcode (10x Flex) protocols are handled.
+//!
+//! ## File format
+//!
+//! ```text
+//! [Header]
+//!   version: u8           (currently 1)
+//!   num_fields: u8        (number of barcode fields per record)
+//!   field_types: [u8; N]  (RadIntId discriminant for each field)
+//!
+//! [Records] (repeated until EOF)
+//!   barcode_0: [width_0 bytes]
+//!   barcode_1: [width_1 bytes]  (if num_fields > 1)
+//!   ...
+//!   count: u32
+//! ```
+
+use crate::rad_types::RadIntId;
+use std::io::{Read, Write};
+
+/// Version marker for the self-describing format.
+pub const UNMAPPED_BC_FORMAT_VERSION: u8 = 1;
+
+/// Describes the record layout of an unmapped barcode count file.
+#[derive(Debug, Clone)]
+pub struct UnmappedBcFormat {
+    /// The RadIntId type for each barcode field.
+    pub field_types: Vec<RadIntId>,
+}
+
+impl UnmappedBcFormat {
+    /// Create a format for a single barcode field.
+    pub fn single(bc_type: RadIntId) -> Self {
+        Self {
+            field_types: vec![bc_type],
+        }
+    }
+
+    /// Create a format for multiple barcode fields.
+    pub fn multi(field_types: Vec<RadIntId>) -> Self {
+        Self { field_types }
+    }
+
+    /// Number of barcode fields per record.
+    pub fn num_fields(&self) -> usize {
+        self.field_types.len()
+    }
+
+    /// Total bytes per record (all barcode fields + u32 count).
+    pub fn record_bytes(&self) -> usize {
+        self.field_types.iter().map(|t| t.size_of()).sum::<usize>() + std::mem::size_of::<u32>()
+    }
+
+    /// Write the header to a writer.
+    pub fn write_header<W: Write>(&self, writer: &mut W) -> anyhow::Result<()> {
+        writer.write_all(&[UNMAPPED_BC_FORMAT_VERSION])?;
+        writer.write_all(&[self.field_types.len() as u8])?;
+        for ft in &self.field_types {
+            let id: u8 = (*ft).into();
+            writer.write_all(&[id])?;
+        }
+        Ok(())
+    }
+
+    /// Read a header from a reader. Returns None if the file is empty.
+    pub fn read_header<R: Read>(reader: &mut R) -> anyhow::Result<Option<Self>> {
+        let mut version_buf = [0u8; 1];
+        match reader.read_exact(&mut version_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(e.into()),
+        }
+
+        let version = version_buf[0];
+        if version != UNMAPPED_BC_FORMAT_VERSION {
+            anyhow::bail!(
+                "Unsupported unmapped BC format version: {} (expected {})",
+                version,
+                UNMAPPED_BC_FORMAT_VERSION,
+            );
+        }
+
+        let mut num_fields_buf = [0u8; 1];
+        reader.read_exact(&mut num_fields_buf)?;
+        let num_fields = num_fields_buf[0] as usize;
+
+        let mut field_types = Vec::with_capacity(num_fields);
+        for _ in 0..num_fields {
+            let mut type_buf = [0u8; 1];
+            reader.read_exact(&mut type_buf)?;
+            field_types.push(RadIntId::from(type_buf[0]));
+        }
+
+        Ok(Some(Self { field_types }))
+    }
+}
+
+/// Writer for unmapped barcode count records.
+///
+/// Accumulates records in memory, then flushes to a writer.
+/// Thread-safe: each thread creates its own `UnmappedBcRecordWriter`,
+/// then flushes to a shared file under a lock.
+pub struct UnmappedBcRecordWriter {
+    format: UnmappedBcFormat,
+    buf: Vec<u8>,
+}
+
+impl UnmappedBcRecordWriter {
+    /// Create a new writer with the given format.
+    /// Does NOT write the header — the caller is responsible for writing
+    /// the header once to the shared output file before any thread flushes.
+    pub fn new(format: UnmappedBcFormat) -> Self {
+        Self {
+            format,
+            buf: Vec::with_capacity(4096),
+        }
+    }
+
+    /// Write a record with barcode values (as u64s, truncated to field width) and a count.
+    pub fn write_record(&mut self, barcodes: &[u64], count: u32) {
+        debug_assert_eq!(barcodes.len(), self.format.num_fields());
+        for (bc, ft) in barcodes.iter().zip(self.format.field_types.iter()) {
+            match ft {
+                RadIntId::U8 => self.buf.extend_from_slice(&(*bc as u8).to_le_bytes()),
+                RadIntId::U16 => self.buf.extend_from_slice(&(*bc as u16).to_le_bytes()),
+                RadIntId::U32 => self.buf.extend_from_slice(&(*bc as u32).to_le_bytes()),
+                RadIntId::U64 => self.buf.extend_from_slice(&bc.to_le_bytes()),
+                _ => panic!("Unsupported RadIntId for unmapped BC: {:?}", ft),
+            }
+        }
+        self.buf.extend_from_slice(&count.to_le_bytes());
+    }
+
+    /// Flush accumulated records to a writer.
+    pub fn flush_to<W: Write>(&mut self, writer: &mut W) -> anyhow::Result<()> {
+        if !self.buf.is_empty() {
+            writer.write_all(&self.buf)?;
+            self.buf.clear();
+        }
+        Ok(())
+    }
+
+    /// Whether any records have been accumulated.
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+}
+
+/// Reader for unmapped barcode count records.
+///
+/// Reads records one at a time, returning barcode values as u64s.
+pub struct UnmappedBcRecordReader {
+    format: UnmappedBcFormat,
+    record_buf: Vec<u8>,
+}
+
+impl UnmappedBcRecordReader {
+    /// Create a reader with the given format (from a parsed header).
+    pub fn new(format: UnmappedBcFormat) -> Self {
+        let record_bytes = format.record_bytes();
+        Self {
+            format,
+            record_buf: vec![0u8; record_bytes],
+        }
+    }
+
+    /// Read the next record. Returns None at EOF.
+    /// On success, returns (barcodes_as_u64, count).
+    pub fn read_record<R: Read>(&mut self, reader: &mut R) -> anyhow::Result<Option<(Vec<u64>, u32)>> {
+        match reader.read_exact(&mut self.record_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(e.into()),
+        }
+
+        let mut offset = 0usize;
+        let mut barcodes = Vec::with_capacity(self.format.num_fields());
+        for ft in &self.format.field_types {
+            let val: u64 = match ft {
+                RadIntId::U8 => self.record_buf[offset] as u64,
+                RadIntId::U16 => {
+                    u16::from_le_bytes(self.record_buf[offset..offset + 2].try_into().unwrap())
+                        as u64
+                }
+                RadIntId::U32 => {
+                    u32::from_le_bytes(self.record_buf[offset..offset + 4].try_into().unwrap())
+                        as u64
+                }
+                RadIntId::U64 => {
+                    u64::from_le_bytes(self.record_buf[offset..offset + 8].try_into().unwrap())
+                }
+                _ => panic!("Unsupported RadIntId for unmapped BC: {:?}", ft),
+            };
+            barcodes.push(val);
+            offset += ft.size_of();
+        }
+
+        let count = u32::from_le_bytes(
+            self.record_buf[offset..offset + 4].try_into().unwrap(),
+        );
+
+        Ok(Some((barcodes, count)))
+    }
+
+    /// Get the underlying format.
+    pub fn format(&self) -> &UnmappedBcFormat {
+        &self.format
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn single_barcode_roundtrip() {
+        let fmt = UnmappedBcFormat::single(RadIntId::U32);
+        assert_eq!(fmt.num_fields(), 1);
+        assert_eq!(fmt.record_bytes(), 8); // u32 + u32
+
+        let mut buf = Vec::new();
+        fmt.write_header(&mut buf).unwrap();
+
+        let mut writer = UnmappedBcRecordWriter::new(fmt.clone());
+        writer.write_record(&[12345], 42);
+        writer.write_record(&[67890], 7);
+        writer.flush_to(&mut buf).unwrap();
+
+        // Read back
+        let mut cursor = Cursor::new(&buf);
+        let read_fmt = UnmappedBcFormat::read_header(&mut cursor).unwrap().unwrap();
+        assert_eq!(read_fmt.num_fields(), 1);
+
+        let mut reader = UnmappedBcRecordReader::new(read_fmt);
+        let (bcs, count) = reader.read_record(&mut cursor).unwrap().unwrap();
+        assert_eq!(bcs, vec![12345]);
+        assert_eq!(count, 42);
+
+        let (bcs, count) = reader.read_record(&mut cursor).unwrap().unwrap();
+        assert_eq!(bcs, vec![67890]);
+        assert_eq!(count, 7);
+
+        assert!(reader.read_record(&mut cursor).unwrap().is_none());
+    }
+
+    #[test]
+    fn multi_barcode_roundtrip() {
+        let fmt = UnmappedBcFormat::multi(vec![RadIntId::U16, RadIntId::U32]);
+        assert_eq!(fmt.num_fields(), 2);
+        assert_eq!(fmt.record_bytes(), 10); // u16 + u32 + u32
+
+        let mut buf = Vec::new();
+        fmt.write_header(&mut buf).unwrap();
+
+        let mut writer = UnmappedBcRecordWriter::new(fmt.clone());
+        writer.write_record(&[0xABCD, 0x12345678], 100);
+        writer.flush_to(&mut buf).unwrap();
+
+        let mut cursor = Cursor::new(&buf);
+        let read_fmt = UnmappedBcFormat::read_header(&mut cursor).unwrap().unwrap();
+        assert_eq!(read_fmt.num_fields(), 2);
+
+        let mut reader = UnmappedBcRecordReader::new(read_fmt);
+        let (bcs, count) = reader.read_record(&mut cursor).unwrap().unwrap();
+        assert_eq!(bcs, vec![0xABCD, 0x12345678]);
+        assert_eq!(count, 100);
+    }
+
+    #[test]
+    fn empty_file() {
+        let cursor = Cursor::new(Vec::<u8>::new());
+        let result = UnmappedBcFormat::read_header(&mut cursor.clone()).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/libradicl/src/unmapped.rs
+++ b/libradicl/src/unmapped.rs
@@ -269,14 +269,11 @@ impl CollatedUnmappedCounts {
             CollatedUnmappedCounts::Single { counts, .. } => {
                 counts.get(&cell_bc).copied().unwrap_or(0)
             }
-            // Fallback: if called on Multi, sum across all samples for this cell
-            CollatedUnmappedCounts::Multi { counts, .. } => {
-                counts
-                    .iter()
-                    .filter(|((_, cb), _)| *cb == cell_bc)
-                    .map(|(_, &c)| c)
-                    .sum()
-            }
+            // For multi-barcode data, we don't have the sample BC here
+            // so we can't do an O(1) lookup. Return 0 rather than doing
+            // an O(n) scan of the entire map — the caller should use
+            // get_multi() with both barcodes for accurate unmapped counts.
+            CollatedUnmappedCounts::Multi { .. } => 0,
         }
     }
 

--- a/libradicl/src/unmapped.rs
+++ b/libradicl/src/unmapped.rs
@@ -179,7 +179,10 @@ impl UnmappedBcRecordReader {
 
     /// Read the next record. Returns None at EOF.
     /// On success, returns (barcodes_as_u64, count).
-    pub fn read_record<R: Read>(&mut self, reader: &mut R) -> anyhow::Result<Option<(Vec<u64>, u32)>> {
+    pub fn read_record<R: Read>(
+        &mut self,
+        reader: &mut R,
+    ) -> anyhow::Result<Option<(Vec<u64>, u32)>> {
         match reader.read_exact(&mut self.record_buf) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
@@ -208,9 +211,7 @@ impl UnmappedBcRecordReader {
             offset += ft.size_of();
         }
 
-        let count = u32::from_le_bytes(
-            self.record_buf[offset..offset + 4].try_into().unwrap(),
-        );
+        let count = u32::from_le_bytes(self.record_buf[offset..offset + 4].try_into().unwrap());
 
         Ok(Some((barcodes, count)))
     }
@@ -321,7 +322,10 @@ impl CollatedUnmappedCounts {
                 }
                 rec_writer.flush_to(writer)?;
             }
-            CollatedUnmappedCounts::Multi { counts, field_types } => {
+            CollatedUnmappedCounts::Multi {
+                counts,
+                field_types,
+            } => {
                 let fmt = UnmappedBcFormat::multi(field_types.clone());
                 fmt.write_header(writer)?;
                 let mut rec_writer = UnmappedBcRecordWriter::new(fmt);
@@ -474,8 +478,8 @@ mod tests {
     #[test]
     fn collated_multi_roundtrip() {
         let mut counts = CollatedUnmappedCounts::new_multi(vec![RadIntId::U16, RadIntId::U32]);
-        counts.insert_multi(1, 100, 5);   // sample 1, cell 100
-        counts.insert_multi(2, 100, 10);  // sample 2, cell 100 (different sample!)
+        counts.insert_multi(1, 100, 5); // sample 1, cell 100
+        counts.insert_multi(2, 100, 10); // sample 2, cell 100 (different sample!)
         counts.insert_multi(1, 200, 3);
 
         assert_eq!(counts.get_multi(1, 100), 5);

--- a/libradicl/src/writers.rs
+++ b/libradicl/src/writers.rs
@@ -69,11 +69,7 @@ impl<W: Write + Seek> RadFileWriter<W> {
     /// Writes the prelude schema (header + three tag-section descriptions) and
     /// the file-level tag values to `writer`, then records the byte offset of
     /// the `num_chunks` field so it can be backpatched in [`Self::finalize`].
-    pub fn new(
-        writer: W,
-        prelude: &RadPrelude,
-        file_tag_values: &TagMap,
-    ) -> anyhow::Result<Self> {
+    pub fn new(writer: W, prelude: &RadPrelude, file_tag_values: &TagMap) -> anyhow::Result<Self> {
         let mut inner = BufWriter::new(writer);
 
         // Compute the byte offset of the num_chunks field *before* writing.
@@ -216,7 +212,9 @@ mod tests {
     use super::*;
     use crate::chunk::{Chunk, ChunkBuf};
     use crate::header::{RadHeader, RadPrelude};
-    use crate::rad_types::{RadIntId, RadType, TagDesc, TagMap, TagSection, TagSectionLabel, TagValue};
+    use crate::rad_types::{
+        RadIntId, RadType, TagDesc, TagMap, TagSection, TagSectionLabel, TagValue,
+    };
     use crate::record::{AlevinFryReadRecord, AlevinFryRecordContext, RecordContext};
     use std::io::Cursor;
 
@@ -396,8 +394,8 @@ mod tests {
         )
         .unwrap();
 
-        let fw = RadFileWriter::new(Cursor::new(Vec::<u8>::new()), &prelude, &file_tag_map)
-            .unwrap();
+        let fw =
+            RadFileWriter::new(Cursor::new(Vec::<u8>::new()), &prelude, &file_tag_map).unwrap();
         let ccw = ConcurrentChunkWriter::new(fw);
 
         // Spawn 4 threads, each writing 1 chunk of 2 records
@@ -411,7 +409,11 @@ mod tests {
                 cbuf.write_record(&rec_clone, &ctx_clone).unwrap();
                 cbuf.write_record(&rec_clone, &ctx_clone).unwrap();
                 let bytes = cbuf.into_bytes();
-                writer_ref.lock().unwrap().write_chunk_bytes(&bytes).unwrap();
+                writer_ref
+                    .lock()
+                    .unwrap()
+                    .write_chunk_bytes(&bytes)
+                    .unwrap();
             }));
         }
         for h in handles {


### PR DESCRIPTION
## Summary
- add multi-barcode record support and hierarchical collation for multi-sample RAD data
- add a self-describing unmapped barcode count format and in-memory CollatedUnmappedCounts support
- fix the remaining clippy warnings so the branch builds cleanly under `cargo clippy --workspace --all-targets --all-features -- -D warnings`

## Testing
- cargo clippy --workspace --all-targets --all-features -- -D warnings